### PR TITLE
XCA-I - add mandatory TransferSyntaxUUIDList

### DIFF
--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/ebxml/EbXMLRetrieveImagingDocumentSetRequest.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/ebxml/EbXMLRetrieveImagingDocumentSetRequest.java
@@ -41,6 +41,17 @@ public interface EbXMLRetrieveImagingDocumentSetRequest
     List<RetrieveStudy> getRetrieveStudies();
 
     /**
+     * Sets the transferSyntaxUIDList of the request.
+     * @param transferSyntaxUIDList  the transferSyntaxUIDList.
+     */
+    void setTransferSyntaxUIDList(List<String> transferSyntaxUIDList);
+
+    /**
+     * @return the transferSyntaxUIDList of the request.
+     */
+    List<String> getTransferSyntaxUIDList();
+
+    /**
      * @return the ebXML object being wrapped by this class. 
      */
     Object getInternal();

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/ebxml/ebxml30/EbXMLRetrieveImagingDocumentSetRequest30.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/ebxml/ebxml30/EbXMLRetrieveImagingDocumentSetRequest30.java
@@ -19,6 +19,7 @@ import org.openehealth.ipf.commons.ihe.xds.core.ebxml.EbXMLRetrieveImagingDocume
 import org.openehealth.ipf.commons.ihe.xds.core.ebxml.ebxml30.RetrieveDocumentSetRequestType.DocumentRequest;
 import org.openehealth.ipf.commons.ihe.xds.core.ebxml.ebxml30.RetrieveImagingDocumentSetRequestType.StudyRequest;
 import org.openehealth.ipf.commons.ihe.xds.core.ebxml.ebxml30.RetrieveImagingDocumentSetRequestType.SeriesRequest;
+import org.openehealth.ipf.commons.ihe.xds.core.ebxml.ebxml30.RetrieveImagingDocumentSetRequestType.TransferSyntaxUIDList;
 import org.openehealth.ipf.commons.ihe.xds.core.requests.RetrieveDocument;
 import org.openehealth.ipf.commons.ihe.xds.core.requests.RetrieveSeries;
 import org.openehealth.ipf.commons.ihe.xds.core.requests.RetrieveStudy;
@@ -77,6 +78,17 @@ public class EbXMLRetrieveImagingDocumentSetRequest30 implements EbXMLRetrieveIm
     }
 
     @Override
+    public List<String> getTransferSyntaxUIDList() {
+        List<String> transferSyntaxUIDs = new ArrayList<String>();
+        TransferSyntaxUIDList transferSyntaxUIDList = request.getTransferSyntaxUIDList().get(0);
+        for (String transferSyntaxUID : transferSyntaxUIDList.getTransferSyntaxUID())
+        {
+            transferSyntaxUIDs.add(transferSyntaxUID);
+        }
+        return transferSyntaxUIDs;
+    }
+
+    @Override
     public void setRetrieveStudies(List<RetrieveStudy> retrieveStudies) {
         request.getStudyRequest().clear();
         if (retrieveStudies != null) {
@@ -101,5 +113,21 @@ public class EbXMLRetrieveImagingDocumentSetRequest30 implements EbXMLRetrieveIm
                 request.getStudyRequest().add(studyRequest);
             }
         }
+    }
+
+    @Override
+    public void setTransferSyntaxUIDList(List<String> transferSyntaxUIDList) {
+        if (!request.getTransferSyntaxUIDList().isEmpty()) {
+          request.getTransferSyntaxUIDList().clear();
+        }
+        request.getTransferSyntaxUIDList().add(new TransferSyntaxUIDList());
+        request.getTransferSyntaxUIDList().get(0).getTransferSyntaxUID().clear();
+        if (transferSyntaxUIDList != null) {
+            for (String transferSyntaxUID : transferSyntaxUIDList)
+            {
+                request.getTransferSyntaxUIDList().get(0).getTransferSyntaxUID().add(transferSyntaxUID);
+            }
+        }
+
     }
 }

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/ebxml/ebxml30/RetrieveImagingDocumentSetRequestType.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/ebxml/ebxml30/RetrieveImagingDocumentSetRequestType.java
@@ -55,6 +55,19 @@ import javax.xml.bind.annotation.*;
  *             &lt;/complexContent>
  *           &lt;/complexType>
  *         &lt;/element>
+ *
+ *        &lt;xs:element name="TransferSyntaxUIDList">
+ *          &lt;xs:complexType>
+ *            &lt;xs:sequence>
+ *              &lt;xs:element name="TransferSyntaxUID" type="rim:LongName" maxOccurs="unbounded">
+ *                &lt;xs:annotation>
+ *                   &lt;xs:documentation>This is the list of DICOM transfer styntax UIDs to be used when requesting retrieval of DICOM images</xs:documentation>
+ *                &lt;/xs:annotation>
+ *              &lt;/xs:element>
+ *            &lt;/xs:sequence>
+ *          &lt;/xs:complexType>
+ *        &lt;/xs:element>
+ *
  *       &lt;/sequence>
  *     &lt;/restriction>
  *   &lt;/complexContent>
@@ -65,12 +78,15 @@ import javax.xml.bind.annotation.*;
 @XmlRootElement(name = "RetrieveImagingDocumentSetRequest")
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "RetrieveImagingDocumentSetRequestType", propOrder = {
-    "studyRequest"
+    "studyRequest", "transferSyntaxUIDList"
 })
 public class RetrieveImagingDocumentSetRequestType {
 
-    @XmlElement(name = "StudyRequest", required = true)
+    @XmlElement(name = "StudyRequest", required = true, namespace = "urn:ihe:rad:xdsi-b:2009")
     protected List<StudyRequest> studyRequest;
+
+    @XmlElement(name = "TransferSyntaxUIDList", required = true, namespace = "urn:ihe:rad:xdsi-b:2009")
+    protected List<TransferSyntaxUIDList> transferSyntaxUIDList;
 
     /**
      * Gets the value of the studyRequest property.
@@ -103,6 +119,36 @@ public class RetrieveImagingDocumentSetRequestType {
     }
 
     /**
+     * Gets the value of the transferSyntaxUIDList property.
+     *
+     * <p>
+     * This accessor method returns a reference to the live list,
+     * not a snapshot. Therefore any modification you make to the
+     * returned list will be present inside the JAXB object.
+     * This is why there is not a <CODE>set</CODE> method for the studyRequest property.
+     *
+     * <p>
+     * For example, to add a new item, do as follows:
+     * <pre>
+     *    getTransferSyntaxUIDList().add(newItem);
+     * </pre>
+     *
+     *
+     * <p>
+     * Objects of the following type(s) are allowed in the list
+     * {@link TransferSyntaxUIDList }
+     *
+     *
+     * @return the study request.
+     */
+    public List<RetrieveImagingDocumentSetRequestType.TransferSyntaxUIDList> getTransferSyntaxUIDList() {
+        if (transferSyntaxUIDList == null) {
+            transferSyntaxUIDList = new ArrayList<TransferSyntaxUIDList>();
+        }
+        return this.transferSyntaxUIDList;
+    }
+
+    /**
      * <p>The following schema fragment specifies the expected content contained within this class.
      *
      * <pre>
@@ -123,10 +169,10 @@ public class RetrieveImagingDocumentSetRequestType {
     @XmlType(name = "", propOrder = {"studyInstanceUID", "seriesRequest"})
     public static class StudyRequest {
 
-        @XmlAttribute(name = "StudyInstanceUID", required = true)
+        @XmlAttribute(name = "studyInstanceUID", required = true)
         protected String studyInstanceUID;
 
-        @XmlElement(name = "SeriesRequest", required = true)
+        @XmlElement(name = "SeriesRequest", required = true, namespace = "urn:ihe:rad:xdsi-b:2009")
         protected List<SeriesRequest> seriesRequest;
 
         /**
@@ -177,6 +223,57 @@ public class RetrieveImagingDocumentSetRequestType {
      * <p>The following schema fragment specifies the expected content contained within this class.
      *
      * <pre>
+     * &lt;xs:element name="TransferSyntaxUIDList">
+     *   &lt;xs:complexType>
+     *     &lt;xs:sequence>
+     *       &lt;xs:element name="TransferSyntaxUID" type="rim:LongName" maxOccurs="unbounded">
+     *         &lt;xs:annotation>
+     *           &lt;xs:documentation>This is the list of DICOM transfer styntax UIDs to be used when requesting retrieval of DICOM images</xs:documentation>
+     *         &lt;/xs:annotation>
+     *       &lt;/xs:element>
+     *     &lt;/xs:sequence>
+     *   &lt;/xs:complexType>
+     * &lt;/xs:element>
+     * </pre>
+     *
+     */
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(name = "", propOrder = {"transferSyntaxUID"})
+    public static class TransferSyntaxUIDList {
+
+        @XmlElement(name = "TransferSyntaxUID", required = true, namespace="urn:ihe:rad:xdsi-b:2009")
+        protected List<String> transferSyntaxUID;
+
+        /**
+         * Gets the value of the seriesRequest property.
+         *
+         * <p>
+         * This accessor method returns a reference to the live list,
+         * not a snapshot. Therefore any modification you make to the
+         * returned list will be present inside the JAXB object.
+         * This is why there is not a <CODE>set</CODE> method for the seriesRequest property.
+         * <p>
+         * For example, to add a new item, do as follows:
+         * <pre>
+         *    getTransferSyntaxUID().add(newItem);
+         * </pre>
+         * <p>
+         * Objects of the following type(s) are allowed in the list {@link TransferSyntaxUIDList }
+         *
+         */
+        public List<String> getTransferSyntaxUID() {
+            if (transferSyntaxUID == null) {
+                transferSyntaxUID = new ArrayList<String>();
+            }
+            return this.transferSyntaxUID;
+        }
+
+    }
+
+    /**
+     * <p>The following schema fragment specifies the expected content contained within this class.
+     *
+     * <pre>
      * &lt;complexType>
      *   &lt;complexContent>
      *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
@@ -194,7 +291,7 @@ public class RetrieveImagingDocumentSetRequestType {
     @XmlType(name = "", propOrder = {"seriesInstanceUID", "documentRequest"})
     public static class SeriesRequest {
 
-        @XmlAttribute(name = "SeriesInstanceUID", required = true)
+        @XmlAttribute(name = "seriesInstanceUID", required = true)
         protected String seriesInstanceUID;
 
         @XmlElement(name = "DocumentRequest", required = true)
@@ -248,4 +345,5 @@ public class RetrieveImagingDocumentSetRequestType {
             return documentRequest;
         }
     }
+
 }

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/RetrieveImagingDocumentSet.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/RetrieveImagingDocumentSet.java
@@ -17,6 +17,7 @@ package org.openehealth.ipf.commons.ihe.xds.core.requests;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+import org.openehealth.ipf.commons.ihe.xds.core.ebxml.ebxml30.RetrieveImagingDocumentSetRequestType;
 
 import javax.xml.bind.annotation.*;
 import java.io.Serializable;
@@ -32,12 +33,15 @@ import java.util.List;
 
 @XmlRootElement(name = "retrieveImagingDocumentSet")
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlType(name = "RetrieveImagingDocumentSet", propOrder = {"retrieveStudies"})
+@XmlType(name = "RetrieveImagingDocumentSet", propOrder = {"retrieveStudies", "transferSyntaxIds"})
 public class RetrieveImagingDocumentSet implements Serializable {
     private static final long serialVersionUID = -8999352499981099419L;
 
     @XmlElementRef
     private final List<RetrieveStudy> retrieveStudies = new ArrayList<RetrieveStudy>();
+
+    @XmlElement
+    private final List<String> transferSyntaxIds = new ArrayList<String>();
 
     /**
      * @return the list of StudyRequests to retrieve.
@@ -46,11 +50,20 @@ public class RetrieveImagingDocumentSet implements Serializable {
         return retrieveStudies;
     }
 
+    /**
+     *
+     * @return the list of TransferSyntaxUID
+     */
+    public List<String> getTransferSyntaxIds() {
+        return transferSyntaxIds;
+    }
+
     @Override
     public int hashCode() {
         final int prime = 31;
         int result = 1;
         result = prime * result + ((retrieveStudies == null) ? 0 : retrieveStudies.hashCode());
+        result = prime * result + ((transferSyntaxIds == null) ? 0 : transferSyntaxIds.hashCode());
         return result;
     }
 
@@ -68,6 +81,11 @@ public class RetrieveImagingDocumentSet implements Serializable {
             if (other.retrieveStudies != null)
                 return false;
         } else if (!retrieveStudies.equals(other.retrieveStudies))
+            return false;
+        if (transferSyntaxIds == null) {
+            if (other.transferSyntaxIds != null)
+                return false;
+        } else if (!transferSyntaxIds.equals(other.transferSyntaxIds))
             return false;
         return true;
     }

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/RetrieveImagingDocumentSetRequestTransformer.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/RetrieveImagingDocumentSetRequestTransformer.java
@@ -17,6 +17,7 @@ package org.openehealth.ipf.commons.ihe.xds.core.transform.requests;
 
 import org.openehealth.ipf.commons.ihe.xds.core.ebxml.EbXMLFactory;
 import org.openehealth.ipf.commons.ihe.xds.core.ebxml.EbXMLRetrieveImagingDocumentSetRequest;
+import org.openehealth.ipf.commons.ihe.xds.core.ebxml.ebxml30.RetrieveImagingDocumentSetRequestType;
 import org.openehealth.ipf.commons.ihe.xds.core.requests.RetrieveImagingDocumentSet;
 
 import static org.apache.commons.lang3.Validate.notNull;
@@ -52,6 +53,7 @@ public class RetrieveImagingDocumentSetRequestTransformer
         
         EbXMLRetrieveImagingDocumentSetRequest ebXML = factory.createRetrieveImagingDocumentSetRequest();
         ebXML.setRetrieveStudies(request.getRetrieveStudies());
+        ebXML.setTransferSyntaxUIDList(request.getTransferSyntaxIds());
         return ebXML;
     }
     
@@ -67,6 +69,7 @@ public class RetrieveImagingDocumentSetRequestTransformer
             
         RetrieveImagingDocumentSet request = new RetrieveImagingDocumentSet();
         request.getRetrieveStudies().addAll(ebXML.getRetrieveStudies());
+        request.getTransferSyntaxIds().addAll(ebXML.getTransferSyntaxUIDList());
         return request;
     }
 }

--- a/commons/ihe/xds/src/main/resources/wsdl/schema/IHE/IHEXDSIB.xsd
+++ b/commons/ihe/xds/src/main/resources/wsdl/schema/IHE/IHEXDSIB.xsd
@@ -1,33 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns="urn:ihe:rad:xdsi-b:2009" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0" xmlns:query="urn:oasis:names:tc:ebxml-regrep:xsd:query:3.0" xmlns:lcm="urn:oasis:names:tc:ebxml-regrep:xsd:lcm:3.0" xmlns:rs="urn:oasis:names:tc:ebxml-regrep:xsd:rs:3.0" targetNamespace="urn:ihe:rad:xdsi-b:2009" xmlns:xmime="http://www.w3.org/2005/05/xmlmime" elementFormDefault="qualified" attributeFormDefault="unqualified">
+<xs:schema xmlns="urn:ihe:rad:xdsi-b:2009" xmlns:xds-b="urn:ihe:iti:xds-b:2007" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0" xmlns:query="urn:oasis:names:tc:ebxml-regrep:xsd:query:3.0" xmlns:lcm="urn:oasis:names:tc:ebxml-regrep:xsd:lcm:3.0" xmlns:rs="urn:oasis:names:tc:ebxml-regrep:xsd:rs:3.0" targetNamespace="urn:ihe:rad:xdsi-b:2009" xmlns:xmime="http://www.w3.org/2005/05/xmlmime" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:import namespace="urn:oasis:names:tc:ebxml-regrep:xsd:rs:3.0" schemaLocation="../ebRS30/rs.xsd"/>
 	<xs:import namespace="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0" schemaLocation="../ebRS30/rim.xsd"/>
 	<xs:import namespace="urn:oasis:names:tc:ebxml-regrep:xsd:lcm:3.0" schemaLocation="../ebRS30/lcm.xsd"/>
     <xs:import namespace="urn:oasis:names:tc:ebxml-regrep:xsd:query:3.0" schemaLocation="../ebRS30/query.xsd"/>
-    <import namespace="urn:ihe:iti:xds-b:2007" schemaLocation="./IHEXDSB.xsd"/>
+    <xs:import namespace="urn:ihe:iti:xds-b:2007" schemaLocation="./IHEXDSB.xsd"/>
     <xs:complexType name="SeriesRequestType">
         <xs:sequence>
-            <xs:element name="seriesInstanceUID" type="rim:LongName" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>This corresponds to the seriesInstanceUID attribute of the SeriesRequest class)</xs:documentation>
                 </xs:annotation>
-            </xs:element>
-            <xs:element name="DocumentRequest" type="DocumentRequestType" maxOccurs="unbounded"/>
+            <xs:element name="DocumentRequest" type="xds-b:DocumentRequestType" maxOccurs="unbounded"/>
         </xs:sequence>
+        <xs:attribute name="seriesInstanceUID" type="rim:LongName" use="required" />
     </xs:complexType>
     <xs:complexType name="StudyRequestType">
         <xs:sequence>
-            <xs:element name="studyInstanceUID" type="rim:LongName" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>This corresponds to the studyInstanceUID attribute of the StudyRequest class)</xs:documentation>
                 </xs:annotation>
-            </xs:element>
             <xs:element name="SeriesRequest" type="SeriesRequestType" maxOccurs="unbounded"/>
         </xs:sequence>
+        <xs:attribute name="studyInstanceUID" type="rim:LongName" use="required" />
     </xs:complexType>
     <xs:complexType name="RetrieveImagingDocumentSetRequestType">
         <xs:sequence>
             <xs:element name="StudyRequest" type="StudyRequestType" maxOccurs="unbounded"/>
+            <xs:element name="TransferSyntaxUIDList">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="TransferSyntaxUID" type="rim:LongName" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>This is the list of DICOM transfer styntax UIDs to be used when requesting retrieval of DICOM images</xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
         </xs:sequence>
     </xs:complexType>
     <xs:element name="RetrieveImagingDocumentSetRequest" type="RetrieveImagingDocumentSetRequestType"/>

--- a/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/SampleData.java
+++ b/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/SampleData.java
@@ -16,6 +16,7 @@
 package org.openehealth.ipf.commons.ihe.xds.core;
 
 import org.openehealth.ipf.commons.ihe.ws.utils.LargeDataSource;
+import org.openehealth.ipf.commons.ihe.xds.core.ebxml.ebxml30.RetrieveImagingDocumentSetRequestType;
 import org.openehealth.ipf.commons.ihe.xds.core.metadata.*;
 import org.openehealth.ipf.commons.ihe.xds.core.requests.*;
 import org.openehealth.ipf.commons.ihe.xds.core.requests.query.*;
@@ -364,6 +365,10 @@ public abstract class SampleData {
         retrieveStudies.add(retrieveStudy1);
         RetrieveStudy retrieveStudy2 = new RetrieveStudy("urn:oid:1.1.2", retrieveSerieses);
         retrieveStudies.add(retrieveStudy2);
+
+        request.getTransferSyntaxIds().add("1.2.840.10008.1.2.4.64");
+        request.getTransferSyntaxIds().add("1.2.840.10008.1.2.4.70");
+
 
         return request;
     }

--- a/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/ebxml30/RetrieveImagingDocumentSetRequestTransformerTest.java
+++ b/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/ebxml30/RetrieveImagingDocumentSetRequestTransformerTest.java
@@ -69,6 +69,10 @@ public class RetrieveImagingDocumentSetRequestTransformerTest
         assertEquals("doc2", doc.getDocumentUniqueId());
         assertEquals("urn:oid:1.2.4", doc.getHomeCommunityId());
         assertEquals("repo2", doc.getRepositoryUniqueId());
+
+        List<String> transferSyntaxUIds = ebXML.getTransferSyntaxUIDList();
+        assertEquals("1.2.840.10008.1.2.4.64", true, transferSyntaxUIds.contains("1.2.840.10008.1.2.4.64"));
+        assertEquals("1.2.840.10008.1.2.4.70", true, transferSyntaxUIds.contains("1.2.840.10008.1.2.4.70"));
      }
     
      @Test


### PR DESCRIPTION
This code change make RAD-69 and RAD-75 works in IPF
