### PR TITLE
Improve error message for invalid status in XDS query

### DIFF
--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/validate/query/StatusValidation.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/validate/query/StatusValidation.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2009 the original author or authors.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *     
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,19 +16,22 @@
 package org.openehealth.ipf.commons.ihe.xds.core.validate.query;
 
 import static org.apache.commons.lang3.Validate.notNull;
-import org.openehealth.ipf.commons.ihe.xds.core.ebxml.EbXMLAdhocQueryRequest;
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.AvailabilityStatus;
-import org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryParameter;
-import org.openehealth.ipf.commons.ihe.xds.core.transform.requests.query.QuerySlotHelper;
-import static org.openehealth.ipf.commons.ihe.xds.core.validate.ValidationMessage.*;
+import static org.openehealth.ipf.commons.ihe.xds.core.validate.ValidationMessage.INVALID_QUERY_PARAMETER_VALUE;
+import static org.openehealth.ipf.commons.ihe.xds.core.validate.ValidationMessage.MISSING_REQUIRED_QUERY_PARAMETER;
+import static org.openehealth.ipf.commons.ihe.xds.core.validate.ValidationMessage.PARAMETER_VALUE_NOT_STRING_LIST;
 import static org.openehealth.ipf.commons.ihe.xds.core.validate.ValidatorAssertions.metaDataAssert;
-import org.openehealth.ipf.commons.ihe.xds.core.validate.XDSMetaDataException;
 
 import java.util.List;
 import java.util.regex.Pattern;
 
+import org.openehealth.ipf.commons.ihe.xds.core.ebxml.EbXMLAdhocQueryRequest;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.AvailabilityStatus;
+import org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryParameter;
+import org.openehealth.ipf.commons.ihe.xds.core.transform.requests.query.QuerySlotHelper;
+import org.openehealth.ipf.commons.ihe.xds.core.validate.XDSMetaDataException;
+
 /**
- * Query parameter validation for parameters that are AvailabilityStatus-based. 
+ * Query parameter validation for parameters that are AvailabilityStatus-based.
  * @author Jens Riemschneider
  */
 public class StatusValidation implements QueryParameterValidation {
@@ -43,13 +46,14 @@ public class StatusValidation implements QueryParameterValidation {
      *          parameter to validate.
      */
     public StatusValidation(QueryParameter param) {
-        notNull(param, "param cannot be null");        
+        notNull(param, "param cannot be null");
         this.param = param;
     }
 
     @Override
     public void validate(EbXMLAdhocQueryRequest request) throws XDSMetaDataException {
         List<String> slotValues = request.getSlotValues(param.getSlotName());
+        metaDataAssert(!slotValues.isEmpty(), MISSING_REQUIRED_QUERY_PARAMETER, slotValues);
         for (String slotValue : slotValues) {
             metaDataAssert(slotValue != null, MISSING_REQUIRED_QUERY_PARAMETER, param);
             metaDataAssert(PATTERN.matcher(slotValue).matches(),
@@ -57,12 +61,14 @@ public class StatusValidation implements QueryParameterValidation {
         }
 
         QuerySlotHelper slots = new QuerySlotHelper(request);
+
         List<AvailabilityStatus> list = slots.toStatus(param);
-        
-        metaDataAssert((list != null ) && (! list.isEmpty()), MISSING_REQUIRED_QUERY_PARAMETER, param);
-        
-        for (AvailabilityStatus status : list) {
-            metaDataAssert(status != null, INVALID_QUERY_PARAMETER_VALUE, param);                
+
+        if (list != null && list.isEmpty()) {
+            for (String value : slots.toStringList(param)) {
+                metaDataAssert(AvailabilityStatus.valueOfOpcode(value) != null, INVALID_QUERY_PARAMETER_VALUE, value);
+            }
         }
+        metaDataAssert(!list.isEmpty(), MISSING_REQUIRED_QUERY_PARAMETER, slotValues);
     }
 }

--- a/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/validate/query/StatusValidationTest.java
+++ b/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/validate/query/StatusValidationTest.java
@@ -1,0 +1,67 @@
+package org.openehealth.ipf.commons.ihe.xds.core.validate.query;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.openehealth.ipf.commons.ihe.xds.core.validate.ValidationMessage.INVALID_QUERY_PARAMETER_VALUE;
+import static org.openehealth.ipf.commons.ihe.xds.core.validate.ValidationMessage.MISSING_REQUIRED_QUERY_PARAMETER;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.openehealth.ipf.commons.ihe.xds.core.SampleData;
+import org.openehealth.ipf.commons.ihe.xds.core.ebxml.EbXMLAdhocQueryRequest;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.AvailabilityStatus;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.QueryRegistry;
+import org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryParameter;
+import org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryRegistryTransformer;
+import org.openehealth.ipf.commons.ihe.xds.core.validate.ValidationMessage;
+import org.openehealth.ipf.commons.ihe.xds.core.validate.XDSMetaDataException;
+
+public class StatusValidationTest {
+    private static final StatusValidation validator = new StatusValidation(QueryParameter.DOC_ENTRY_STATUS);
+
+    @Test
+    public void validateStatusSuccess() {
+        validator.validate(validQueryRequestWithStatus());
+    }
+
+    @Test
+    public void ignoreInvalidContentIfValidIsAlsoPresent() {
+        validator.validate(
+                invalidQueryRequestWithStatus("('invalid', '" + AvailabilityStatus.APPROVED.getQueryOpcode() + "')"));
+    }
+
+    @Test
+    public void onlyInvalidContentIsPresent() {
+        expectValidationError(INVALID_QUERY_PARAMETER_VALUE, invalidQueryRequestWithStatus("('invalid')"));
+    }
+
+    @Test
+    public void noStatusIsPresent() {
+        expectValidationError(MISSING_REQUIRED_QUERY_PARAMETER, invalidQueryRequestWithStatus(null));
+    }
+
+    private void expectValidationError(ValidationMessage expectedError, EbXMLAdhocQueryRequest request) {
+        try {
+            validator.validate(request);
+            fail("XDSMetaDataException expected");
+        } catch (XDSMetaDataException e) {
+            assertEquals(0, e.getValidationMessage().compareTo(expectedError));
+        }
+    }
+
+    private EbXMLAdhocQueryRequest invalidQueryRequestWithStatus(String statusQuery) {
+        QueryRegistry createFindDocumentsQuery = SampleData.createFindDocumentsQuery();
+        EbXMLAdhocQueryRequest ebXML = new QueryRegistryTransformer().toEbXML(createFindDocumentsQuery);
+        List<String> slotValues = ebXML.getSlotValues(QueryParameter.DOC_ENTRY_STATUS.getSlotName());
+        slotValues.clear();
+        if (statusQuery != null)
+            slotValues.add(statusQuery);
+        return ebXML;
+    }
+
+    private EbXMLAdhocQueryRequest validQueryRequestWithStatus() {
+        QueryRegistry createFindDocumentsQuery = SampleData.createFindDocumentsQuery();
+        return new QueryRegistryTransformer().toEbXML(createFindDocumentsQuery);
+    }
+}

--- a/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/validate/requests/AdhocQueryRequestValidatorTest.java
+++ b/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/validate/requests/AdhocQueryRequestValidatorTest.java
@@ -132,7 +132,7 @@ public class AdhocQueryRequestValidatorTest {
         valueList.clear();
         valueList.add("('lol')");
         valueList.add("('foo')");
-        expectFailure(MISSING_REQUIRED_QUERY_PARAMETER, ebXML, ITI_18);
+        expectFailure(INVALID_QUERY_PARAMETER_VALUE, ebXML, ITI_18);
 
         // at least one code -- should pass
         valueList.set(0, "('bar')");


### PR DESCRIPTION
In case the client provide a invalid xds query status, the error returned indicate that the query status is missing, but it was invalid instead. Ipf had already a error text for that purpose, but the code block was never reached.