### PR TITLE
Stream already read due to XdsRenderingUtils already consume it

### DIFF
--- a/commons/ihe/ws/src/main/java/org/openehealth/ipf/commons/ihe/ws/cxf/NonReadingAttachmentMarshaller.java
+++ b/commons/ihe/ws/src/main/java/org/openehealth/ipf/commons/ihe/ws/cxf/NonReadingAttachmentMarshaller.java
@@ -15,6 +15,8 @@
  */
 package org.openehealth.ipf.commons.ihe.ws.cxf;
 
+import java.util.Objects;
+
 import javax.activation.DataHandler;
 import javax.xml.bind.attachment.AttachmentMarshaller;
 
@@ -49,9 +51,13 @@ public class NonReadingAttachmentMarshaller extends AttachmentMarshaller {
     }
 
     private static String attachmentDescription(String name, String size, String contentType) {
-        return "Attachment: name='" + name != null ? name : "[unknown]" +
-                "', size='" + size != null ? size : "[unknown]" +
-                "', content type='" + contentType != null ? contentType : "[unknown]" + '\'';
+        return "Attachment: name='" + valueOrUnknown(name) +
+                "', size='" + valueOrUnknown(size) +
+                "', content type='" + valueOrUnknown(contentType) + '\'';
+    }
+
+    private static String valueOrUnknown(String value) {
+        return Objects.toString(value, "[unknown]");
     }
 
 }

--- a/commons/ihe/ws/src/test/java/org/openehealth/ipf/commons/ihe/ws/cxf/NonReadingAttachmentMarshallerTest.java
+++ b/commons/ihe/ws/src/test/java/org/openehealth/ipf/commons/ihe/ws/cxf/NonReadingAttachmentMarshallerTest.java
@@ -1,0 +1,17 @@
+package org.openehealth.ipf.commons.ihe.ws.cxf;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.activation.DataHandler;
+
+import org.junit.Test;
+
+public class NonReadingAttachmentMarshallerTest {
+    private NonReadingAttachmentMarshaller classUnderTest = new NonReadingAttachmentMarshaller();
+
+    @Test
+    public void mtomAttachmentWithoutName() {
+        assertEquals("Attachment: name='[unknown]', size='[unknown]', content type='text/xml'",
+                classUnderTest.addMtomAttachment(new DataHandler("myobject", "text/xml"), null, null));
+    }
+}


### PR DESCRIPTION
While upgrade from IPF 3.4 to IPF 3.5.1 we have identified an issue that running `XdsRenderingUtils.render `on a RetrieveDocumentSetResponseType exchange (containing a attachment stream) cause that the stream is not readable afterwards. We have identified that starting with IPF 3.5 `org.openehealth.ipf.commons.ihe.ws.cxf.NonReadingAttachmentMarshaller.attachmentDescription(String, String, String)` now return null instead of a hum string - this cause that Jaxb will access the attachment stream.