### PR TITLE
XDS validation error message do not contain the slotname for StatusSlot Validation

### DIFF
--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/validate/query/StatusValidation.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/validate/query/StatusValidation.java
@@ -53,7 +53,7 @@ public class StatusValidation implements QueryParameterValidation {
     @Override
     public void validate(EbXMLAdhocQueryRequest request) throws XDSMetaDataException {
         List<String> slotValues = request.getSlotValues(param.getSlotName());
-        metaDataAssert(!slotValues.isEmpty(), MISSING_REQUIRED_QUERY_PARAMETER, slotValues);
+        metaDataAssert(!slotValues.isEmpty(), MISSING_REQUIRED_QUERY_PARAMETER, param);
         for (String slotValue : slotValues) {
             metaDataAssert(slotValue != null, MISSING_REQUIRED_QUERY_PARAMETER, param);
             metaDataAssert(PATTERN.matcher(slotValue).matches(),


### PR DESCRIPTION
My change 
https://github.com/oehf/ipf/commit/5d7c25e4f2c3efed44a7585335076dada9639b37#diff-9615a4ecf7ae271ab2af0725246659aa
introduced a small issue if the status slot is not present at all. The "final" error message that the client get do not contain the slotname.
IPF 3.4: Missing required query parameter: $XDSDocumentEntryStatus
IPF 3.5: Missing required query parameter: []

I have fixed this issue with this pull request. Please also merge to 3.5-branch.