### PR TITLE
Enhance atna log events to RAD-69 and RAD-75.

### DIFF
--- a/commons/ihe/core/src/main/java/org/openehealth/ipf/commons/ihe/core/atna/event/ImageAccessAuditBuilder.java
+++ b/commons/ihe/core/src/main/java/org/openehealth/ipf/commons/ihe/core/atna/event/ImageAccessAuditBuilder.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openehealth.ipf.commons.ihe.core.atna.event;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.openehealth.ipf.commons.audit.AuditContext;
+import org.openehealth.ipf.commons.audit.codes.EventActionCode;
+import org.openehealth.ipf.commons.audit.codes.EventOutcomeIndicator;
+import org.openehealth.ipf.commons.audit.codes.ParticipantObjectDataLifeCycle;
+import org.openehealth.ipf.commons.audit.codes.ParticipantObjectTypeCode;
+import org.openehealth.ipf.commons.audit.codes.ParticipantObjectTypeCodeRole;
+import org.openehealth.ipf.commons.audit.event.DicomInstancesAccessedBuilder;
+import org.openehealth.ipf.commons.audit.model.TypeValuePairType;
+import org.openehealth.ipf.commons.audit.types.EventType;
+import org.openehealth.ipf.commons.audit.types.ParticipantObjectIdType;
+import org.openehealth.ipf.commons.audit.types.PurposeOfUse;
+import org.openehealth.ipf.commons.ihe.core.atna.AuditDataset;
+
+/**
+ * Builder for building IHE-specific DataExport events. It automatically sets the AuditSource, local and remote
+ * ActiveParticipant and a Human Requestor and provides methods for adding patient IDs.
+ *
+ * @author Christian Ohr
+ * @author Eugen Fischer
+ * @since 3.5
+ */
+public class ImageAccessAuditBuilder<T extends ImageAccessAuditBuilder<T>>
+        extends IHEAuditMessageBuilder<T, DicomInstancesAccessedBuilder> {
+
+    public ImageAccessAuditBuilder(final AuditContext auditContext,
+            final AuditDataset auditDataset,
+            final EventActionCode eventActionCode,
+            final EventType eventType,
+            final PurposeOfUse... purposesOfUse) {
+        this(auditContext, auditDataset, auditDataset.getEventOutcomeIndicator(),
+                auditDataset.getEventOutcomeDescription(),
+                eventActionCode, eventType, purposesOfUse);
+    }
+
+    public ImageAccessAuditBuilder(final AuditContext auditContext,
+            final AuditDataset auditDataset,
+            final EventOutcomeIndicator eventOutcomeIndicator,
+            final String eventOutcomeDescription,
+            final EventActionCode eventActionCode,
+            final EventType eventType,
+            final PurposeOfUse... purposesOfUse) {
+        super(auditContext, new DicomInstancesAccessedBuilder(
+                eventOutcomeIndicator,
+                eventOutcomeDescription,
+                eventActionCode,
+                eventType,
+                purposesOfUse));
+
+        // First the source, then the destination
+        if (auditDataset.isServerSide()) {
+            setRemoteParticipant(auditDataset);
+            addHumanRequestor(auditDataset);
+            setLocalParticipant(auditDataset);
+        } else {
+            setLocalParticipant(auditDataset);
+            addHumanRequestor(auditDataset);
+            setRemoteParticipant(auditDataset);
+        }
+    }
+
+    public T setPatient(final String patientId) {
+        if (patientId != null) {
+            delegate.addPatientParticipantObject(
+                    patientId,
+                    null,
+                    Collections.emptyList(),
+                    null);
+        }
+        return self();
+    }
+
+    public T addExportedEntity(
+            final String objectId,
+            final ParticipantObjectIdType participantObjectIdType,
+            final ParticipantObjectTypeCodeRole participantObjectTypeCodeRole,
+            final List<TypeValuePairType> details) {
+        return addExportedEntity(
+                objectId,
+                participantObjectIdType,
+                ParticipantObjectTypeCode.System,
+                participantObjectTypeCodeRole,
+                null,
+                details);
+    }
+
+    public T addExportedEntity(
+            final String objectId,
+            final ParticipantObjectIdType participantObjectIdType,
+            final ParticipantObjectTypeCode participantObjectTypeCode,
+            final ParticipantObjectTypeCodeRole participantObjectTypeCodeRole,
+            final ParticipantObjectDataLifeCycle participantObjectDataLifeCycle,
+            final List<TypeValuePairType> details) {
+        delegate.addParticipantObjectIdentification(
+                requireNonNull(participantObjectIdType, "Exported entity ID type must not be null"),
+                null,
+                null,
+                details,
+                objectId != null ? objectId : getAuditContext().getAuditValueIfMissing(),
+                participantObjectTypeCode,
+                participantObjectTypeCodeRole,
+                participantObjectDataLifeCycle,
+                null);
+        return self();
+    }
+
+    @Override
+    public void validate() {
+        super.validate();
+    }
+}

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/audit/event/ImageAccessBuilder.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/audit/event/ImageAccessBuilder.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openehealth.ipf.commons.ihe.xds.core.audit.event;
+
+import java.util.Collections;
+import java.util.stream.IntStream;
+
+import org.openehealth.ipf.commons.audit.AuditContext;
+import org.openehealth.ipf.commons.audit.codes.EventActionCode;
+import org.openehealth.ipf.commons.audit.codes.EventOutcomeIndicator;
+import org.openehealth.ipf.commons.audit.codes.ParticipantObjectIdTypeCode;
+import org.openehealth.ipf.commons.audit.codes.ParticipantObjectTypeCodeRole;
+import org.openehealth.ipf.commons.audit.types.EventType;
+import org.openehealth.ipf.commons.audit.types.PurposeOfUse;
+import org.openehealth.ipf.commons.ihe.core.atna.AuditDataset;
+import org.openehealth.ipf.commons.ihe.core.atna.event.ImageAccessAuditBuilder;
+import org.openehealth.ipf.commons.ihe.xds.core.audit.XdsNonconstructiveDocumentSetRequestAuditDataset;
+import org.openehealth.ipf.commons.ihe.xds.core.audit.XdsSubmitAuditDataset;
+
+/**
+ * @author Christian Ohr
+ * @quthor Eugen Fischer
+ * @since 3.5
+ */
+public class ImageAccessBuilder extends ImageAccessAuditBuilder<ImageAccessBuilder> {
+
+    public ImageAccessBuilder(final AuditContext auditContext,
+            final AuditDataset auditDataset,
+            final EventOutcomeIndicator eventOutcomeIndicator,
+            final String eventOutcomeDescription,
+            final EventActionCode eventActionCode,
+            final EventType eventType,
+            final PurposeOfUse... purposesOfUse) {
+        super(auditContext, auditDataset, eventOutcomeIndicator, eventOutcomeDescription, eventActionCode, eventType,
+                purposesOfUse);
+    }
+
+    public ImageAccessBuilder setSubmissionSet(final XdsSubmitAuditDataset auditDataset) {
+        return addExportedEntity(auditDataset.getSubmissionSetUuid(),
+                ParticipantObjectIdTypeCode.XdsMetadata,
+                ParticipantObjectTypeCodeRole.Job,
+                Collections.emptyList());
+    }
+
+    public ImageAccessBuilder setSubmissionSetWithHomeCommunityId(final XdsSubmitAuditDataset auditDataset,
+            final boolean xcaHomeCommunityId) {
+        return addExportedEntity(auditDataset.getSubmissionSetUuid(),
+                ParticipantObjectIdTypeCode.XdsMetadata,
+                ParticipantObjectTypeCodeRole.Job,
+                documentDetails(null, auditDataset.getHomeCommunityId(), null, null, xcaHomeCommunityId));
+    }
+
+    public ImageAccessBuilder addDocumentIds(final XdsNonconstructiveDocumentSetRequestAuditDataset auditDataset,
+            final XdsNonconstructiveDocumentSetRequestAuditDataset.Status status,
+            final boolean xcaHomeCommunityId) {
+        final String[] documentIds = auditDataset.getDocumentIds(status);
+        final String[] homeCommunityIds = auditDataset.getHomeCommunityIds(status);
+        final String[] repositoryIds = auditDataset.getRepositoryIds(status);
+        final String[] seriesInstanceIds = auditDataset.getSeriesInstanceIds(status);
+        final String[] studyInstanceIds = auditDataset.getStudyInstanceIds(status);
+        IntStream.range(0, documentIds.length).forEach(i ->
+                addExportedEntity(
+                        documentIds[i],
+                        ParticipantObjectIdTypeCode.ReportNumber,
+                        ParticipantObjectTypeCodeRole.Report,
+                        documentDetails(repositoryIds[i], homeCommunityIds[i], seriesInstanceIds[i],
+                                studyInstanceIds[i], xcaHomeCommunityId)));
+        return self();
+    }
+
+}

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/rad69/Rad69ServerAuditStrategy.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/rad69/Rad69ServerAuditStrategy.java
@@ -15,22 +15,23 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.rad69;
 
+import java.util.stream.Stream;
+
 import org.openehealth.ipf.commons.audit.AuditContext;
 import org.openehealth.ipf.commons.audit.codes.EventActionCode;
 import org.openehealth.ipf.commons.audit.model.AuditMessage;
-import org.openehealth.ipf.commons.ihe.xds.core.audit.event.XdsPHIExportBuilder;
-import org.openehealth.ipf.commons.ihe.xds.core.audit.codes.XdsEventTypeCode;
 import org.openehealth.ipf.commons.ihe.xds.core.audit.XdsIRetrieveAuditStrategy30;
 import org.openehealth.ipf.commons.ihe.xds.core.audit.XdsNonconstructiveDocumentSetRequestAuditDataset;
 import org.openehealth.ipf.commons.ihe.xds.core.audit.XdsNonconstructiveDocumentSetRequestAuditDataset.Status;
-
-import java.util.stream.Stream;
+import org.openehealth.ipf.commons.ihe.xds.core.audit.codes.XdsEventTypeCode;
+import org.openehealth.ipf.commons.ihe.xds.core.audit.event.ImageAccessBuilder;
 
 /**
  * Audit strategy for RAD-69.
  *
  * @author Clay Sebourn
  * @author Christian Ohr
+ * @author Eugen Fischer
  */
 public class Rad69ServerAuditStrategy extends XdsIRetrieveAuditStrategy30 {
 
@@ -39,15 +40,17 @@ public class Rad69ServerAuditStrategy extends XdsIRetrieveAuditStrategy30 {
     }
 
     @Override
-    public AuditMessage[] makeAuditMessage(AuditContext auditContext, XdsNonconstructiveDocumentSetRequestAuditDataset auditDataset) {
+    public AuditMessage[] makeAuditMessage(
+            final AuditContext auditContext, final XdsNonconstructiveDocumentSetRequestAuditDataset auditDataset) {
         return Stream.of(Status.values())
                 .filter(auditDataset::hasDocuments)
                 .map(s -> doMakeAuditMessage(auditContext, auditDataset, s))
                 .toArray(AuditMessage[]::new);
     }
 
-    private AuditMessage doMakeAuditMessage(AuditContext auditContext, XdsNonconstructiveDocumentSetRequestAuditDataset auditDataset, Status status) {
-        return new XdsPHIExportBuilder(auditContext, auditDataset,
+    private AuditMessage doMakeAuditMessage(
+            final AuditContext auditContext, final XdsNonconstructiveDocumentSetRequestAuditDataset auditDataset, final Status status) {
+        return new ImageAccessBuilder(auditContext, auditDataset,
                 auditDataset.getEventOutcomeIndicator(status), null,
                 EventActionCode.Read,
                 XdsEventTypeCode.RetrieveImagingDocumentSet, auditDataset.getPurposesOfUse())

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/rad75/Rad75ServerAuditStrategy.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/rad75/Rad75ServerAuditStrategy.java
@@ -15,22 +15,23 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.rad75;
 
+import java.util.stream.Stream;
+
 import org.openehealth.ipf.commons.audit.AuditContext;
 import org.openehealth.ipf.commons.audit.codes.EventActionCode;
 import org.openehealth.ipf.commons.audit.model.AuditMessage;
-import org.openehealth.ipf.commons.ihe.xds.core.audit.event.XdsPHIExportBuilder;
-import org.openehealth.ipf.commons.ihe.xds.core.audit.codes.XdsEventTypeCode;
 import org.openehealth.ipf.commons.ihe.xds.core.audit.XdsIRetrieveAuditStrategy30;
 import org.openehealth.ipf.commons.ihe.xds.core.audit.XdsNonconstructiveDocumentSetRequestAuditDataset;
 import org.openehealth.ipf.commons.ihe.xds.core.audit.XdsNonconstructiveDocumentSetRequestAuditDataset.Status;
-
-import java.util.stream.Stream;
+import org.openehealth.ipf.commons.ihe.xds.core.audit.codes.XdsEventTypeCode;
+import org.openehealth.ipf.commons.ihe.xds.core.audit.event.ImageAccessBuilder;
 
 /**
  * Audit strategy for RAD-75.
  *
  * @author Clay Sebourn
  * @author Christian Ohr
+ * @author Eugen Fischer
  */
 public class Rad75ServerAuditStrategy extends XdsIRetrieveAuditStrategy30 {
 
@@ -39,15 +40,17 @@ public class Rad75ServerAuditStrategy extends XdsIRetrieveAuditStrategy30 {
     }
 
     @Override
-    public AuditMessage[] makeAuditMessage(AuditContext auditContext, XdsNonconstructiveDocumentSetRequestAuditDataset auditDataset) {
+    public AuditMessage[] makeAuditMessage(
+            final AuditContext auditContext, final XdsNonconstructiveDocumentSetRequestAuditDataset auditDataset) {
         return Stream.of(Status.values())
                 .filter(auditDataset::hasDocuments)
                 .map(s -> doMakeAuditMessage(auditContext, auditDataset, s))
                 .toArray(AuditMessage[]::new);
     }
 
-    private AuditMessage doMakeAuditMessage(AuditContext auditContext, XdsNonconstructiveDocumentSetRequestAuditDataset auditDataset, Status status) {
-        return new XdsPHIExportBuilder(auditContext, auditDataset,
+    private AuditMessage doMakeAuditMessage(
+            final AuditContext auditContext, final XdsNonconstructiveDocumentSetRequestAuditDataset auditDataset, final Status status) {
+        return new ImageAccessBuilder(auditContext, auditDataset,
                 auditDataset.getEventOutcomeIndicator(status), null,
                 EventActionCode.Read,
                 XdsEventTypeCode.CrossGatewayRetrieveImagingDocumentSet, auditDataset.getPurposesOfUse())

--- a/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/rad69/Rad69AuditStrategyTest.java
+++ b/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/rad69/Rad69AuditStrategyTest.java
@@ -53,7 +53,7 @@ public class Rad69AuditStrategyTest extends XdsAuditorTestBase {
 
         assertCommonXdsAuditAttributes(auditMessage,
                 EventOutcomeIndicator.Success,
-                serverSide ? EventIdCode.Export : EventIdCode.Import,
+                serverSide ? EventIdCode.DICOMInstancesAccessed : EventIdCode.Import,
                 serverSide ? EventActionCode.Read : EventActionCode.Create,
                 serverSide,
                 true);

--- a/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/rad75/Rad75AuditStrategyTest.java
+++ b/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/rad75/Rad75AuditStrategyTest.java
@@ -53,7 +53,7 @@ public class Rad75AuditStrategyTest extends XdsAuditorTestBase {
 
         assertCommonXdsAuditAttributes(auditMessage,
                 EventOutcomeIndicator.Success,
-                serverSide ? EventIdCode.Export : EventIdCode.Import,
+                serverSide ? EventIdCode.DICOMInstancesAccessed : EventIdCode.Import,
                 serverSide ? EventActionCode.Read : EventActionCode.Create,
                 serverSide,
                 true);

--- a/platform-camel/ihe/xds/src/test/groovy/org/openehealth/ipf/platform/camel/ihe/xds/rad69/TestRad69.groovy
+++ b/platform-camel/ihe/xds/src/test/groovy/org/openehealth/ipf/platform/camel/ihe/xds/rad69/TestRad69.groovy
@@ -97,7 +97,7 @@ class TestRad69 extends XdsStandardTestContainer {
         assert message.activeParticipants.size() == 2
         assert message.participantObjectIdentifications.size() == 8
         
-        checkEvent(message.eventIdentification, '110106', 'RAD-69', EventActionCode.Read, outcome)
+        checkEvent(message.eventIdentification, '110103', 'RAD-69', EventActionCode.Read, outcome)
         checkSource(message.activeParticipants[0], SERVICE2_ADDR, false)
         checkDestination(message.activeParticipants[1], false, false)
         checkAuditSource(message.auditSourceIdentification, 'sourceId')


### PR DESCRIPTION
According the spec (IHE_RAD_TF_Vol3), on Retrieve Imaging Document Set [RAD-69] and Cross Gateway Retrieve Imaging Document Set [RAD-75] the EventCodeType DICOM Instances Accessed should be used.