### PR TITLE
Adapt audit logs for RAD-69 and RAD 75

### DIFF
--- a/commons/audit/src/main/java/org/openehealth/ipf/commons/audit/event/BaseAuditMessageBuilder.java
+++ b/commons/audit/src/main/java/org/openehealth/ipf/commons/audit/event/BaseAuditMessageBuilder.java
@@ -15,16 +15,39 @@
  */
 package org.openehealth.ipf.commons.audit.event;
 
-import org.openehealth.ipf.commons.audit.AuditContext;
-import org.openehealth.ipf.commons.audit.codes.*;
-import org.openehealth.ipf.commons.audit.model.*;
-import org.openehealth.ipf.commons.audit.types.*;
+import static java.util.Objects.requireNonNull;
 
 import java.time.Instant;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
-import static java.util.Objects.requireNonNull;
+import org.openehealth.ipf.commons.audit.AuditContext;
+import org.openehealth.ipf.commons.audit.codes.ActiveParticipantRoleIdCode;
+import org.openehealth.ipf.commons.audit.codes.EventActionCode;
+import org.openehealth.ipf.commons.audit.codes.EventOutcomeIndicator;
+import org.openehealth.ipf.commons.audit.codes.NetworkAccessPointTypeCode;
+import org.openehealth.ipf.commons.audit.codes.ParticipantObjectDataLifeCycle;
+import org.openehealth.ipf.commons.audit.codes.ParticipantObjectIdTypeCode;
+import org.openehealth.ipf.commons.audit.codes.ParticipantObjectTypeCode;
+import org.openehealth.ipf.commons.audit.codes.ParticipantObjectTypeCodeRole;
+import org.openehealth.ipf.commons.audit.model.ActiveParticipantType;
+import org.openehealth.ipf.commons.audit.model.AuditMessage;
+import org.openehealth.ipf.commons.audit.model.AuditSourceIdentificationType;
+import org.openehealth.ipf.commons.audit.model.DicomObjectDescriptionType;
+import org.openehealth.ipf.commons.audit.model.EventIdentificationType;
+import org.openehealth.ipf.commons.audit.model.ParticipantObjectIdentificationType;
+import org.openehealth.ipf.commons.audit.model.TypeValuePairType;
+import org.openehealth.ipf.commons.audit.types.ActiveParticipantRoleId;
+import org.openehealth.ipf.commons.audit.types.AuditSource;
+import org.openehealth.ipf.commons.audit.types.EventId;
+import org.openehealth.ipf.commons.audit.types.EventType;
+import org.openehealth.ipf.commons.audit.types.MediaType;
+import org.openehealth.ipf.commons.audit.types.ParticipantObjectIdType;
+import org.openehealth.ipf.commons.audit.types.PurposeOfUse;
 
 /**
  * AuditMessage builder with some protected helper methods that are called by subclasses in order to add
@@ -348,17 +371,17 @@ public abstract class BaseAuditMessageBuilder<T extends BaseAuditMessageBuilder<
      * @param objectDetails objectDetails
      * @return this
      */
-    public T addStudyParticipantObject(String studyId, List<TypeValuePairType> objectDetails) {
-        return addParticipantObjectIdentification(
-                ParticipantObjectIdTypeCode.StudyInstanceUID,
-                studyId,
-                null,
-                objectDetails,
-                requireNonNull(studyId, "study ID must be not null"),
-                ParticipantObjectTypeCode.System,
-                ParticipantObjectTypeCodeRole.Report,
-                null,
-                null);
+    public T addStudyParticipantObject(final String studyId, final List<TypeValuePairType> objectDetails) {
+        final ParticipantObjectIdentificationType poit =
+                new ParticipantObjectIdentificationType(studyId, ParticipantObjectIdTypeCode.StudyInstanceUID);
+        poit.setParticipantObjectName(studyId);
+        poit.getParticipantObjectDetails().addAll(objectDetails);
+        final DicomObjectDescriptionType dicomObjectDescriptionType = new DicomObjectDescriptionType();
+        dicomObjectDescriptionType.getStudyIDs().add(studyId);
+        poit.getParticipantObjectDescriptions().add(dicomObjectDescriptionType);
+        poit.setParticipantObjectTypeCode(ParticipantObjectTypeCode.System);
+        poit.setParticipantObjectTypeCodeRole(ParticipantObjectTypeCodeRole.Report);
+        return addParticipantObjectIdentification(poit);
     }
 
 
@@ -376,28 +399,23 @@ public abstract class BaseAuditMessageBuilder<T extends BaseAuditMessageBuilder<
      * @param objectSensitivity   The Participant Object sensitivity
      * @return this
      */
-    public T addParticipantObjectIdentification(ParticipantObjectIdType objectIDTypeCode,
-                                                String objectName,
-                                                byte[] objectQuery,
-                                                List<TypeValuePairType> objectDetails,
-                                                String objectID,
-                                                ParticipantObjectTypeCode objectTypeCode,
-                                                ParticipantObjectTypeCodeRole objectTypeCodeRole,
-                                                ParticipantObjectDataLifeCycle objectDataLifeCycle,
-                                                String objectSensitivity) {
-        ParticipantObjectIdentificationType poit = new ParticipantObjectIdentificationType(objectID, objectIDTypeCode);
+    public T addParticipantObjectIdentification(final ParticipantObjectIdType objectIDTypeCode,
+            final String objectName,
+            final byte[] objectQuery,
+            final List<TypeValuePairType> objectDetails,
+            final String objectID,
+            final ParticipantObjectTypeCode objectTypeCode,
+            final ParticipantObjectTypeCodeRole objectTypeCodeRole,
+            final ParticipantObjectDataLifeCycle objectDataLifeCycle,
+            final String objectSensitivity) {
+        final ParticipantObjectIdentificationType poit = new ParticipantObjectIdentificationType(objectID, objectIDTypeCode);
 
         poit.setParticipantObjectName(objectName);
         poit.setParticipantObjectQuery(objectQuery);
-        if (objectDetails != null) {
+        if (null != objectDetails) {
             objectDetails.stream()
                     .filter(Objects::nonNull)
                     .forEach(objectDetail -> poit.getParticipantObjectDetails().add(objectDetail));
-        }
-        if(ParticipantObjectIdTypeCode.StudyInstanceUID.equals(objectIDTypeCode)){
-            final DicomObjectDescriptionType dicomObjectDescriptionType = new DicomObjectDescriptionType();
-            dicomObjectDescriptionType.getStudyIDs().add(objectID);
-            poit.getParticipantObjectDescriptions().add(dicomObjectDescriptionType);
         }
         poit.setParticipantObjectTypeCode(objectTypeCode);
         poit.setParticipantObjectTypeCodeRole(objectTypeCodeRole);

--- a/commons/audit/src/main/java/org/openehealth/ipf/commons/audit/event/BaseAuditMessageBuilder.java
+++ b/commons/audit/src/main/java/org/openehealth/ipf/commons/audit/event/BaseAuditMessageBuilder.java
@@ -394,6 +394,11 @@ public abstract class BaseAuditMessageBuilder<T extends BaseAuditMessageBuilder<
                     .filter(Objects::nonNull)
                     .forEach(objectDetail -> poit.getParticipantObjectDetails().add(objectDetail));
         }
+        if(ParticipantObjectIdTypeCode.StudyInstanceUID.equals(objectIDTypeCode)){
+            final DicomObjectDescriptionType dicomObjectDescriptionType = new DicomObjectDescriptionType();
+            dicomObjectDescriptionType.getStudyIDs().add(objectID);
+            poit.getParticipantObjectDescriptions().add(dicomObjectDescriptionType);
+        }
         poit.setParticipantObjectTypeCode(objectTypeCode);
         poit.setParticipantObjectTypeCodeRole(objectTypeCodeRole);
         poit.setParticipantObjectDataLifeCycle(objectDataLifeCycle);

--- a/commons/audit/src/main/java/org/openehealth/ipf/commons/audit/marshal/dicom/DICOM2016a.java
+++ b/commons/audit/src/main/java/org/openehealth/ipf/commons/audit/marshal/dicom/DICOM2016a.java
@@ -196,10 +196,10 @@ public class DICOM2016a implements SerializationStrategy {
             pod.addContent(sopClass);
         });
         if (!dicomObjectDescription.getStudyIDs().isEmpty()) {
-            Element participantObjectContainsStudy = new Element("ParticipantObjectContainsStudy ");
+            Element participantObjectContainsStudy = new Element("ParticipantObjectContainsStudy");
             dicomObjectDescription.getStudyIDs().forEach(studyID ->
                     participantObjectContainsStudy.addContent(
-                            new Element("StudyIDs ")
+                            new Element("StudyIDs")
                                     .setAttribute("UID", studyID)));
             pod.addContent(participantObjectContainsStudy);
         }

--- a/commons/audit/src/main/java/org/openehealth/ipf/commons/audit/model/ParticipantObjectIdentificationType.java
+++ b/commons/audit/src/main/java/org/openehealth/ipf/commons/audit/model/ParticipantObjectIdentificationType.java
@@ -147,7 +147,7 @@ public class ParticipantObjectIdentificationType implements Serializable, Valida
     @Override
     public void validate() {
         if (participantObjectIDTypeCode == ParticipantObjectIdTypeCode.StudyInstanceUID &&
-                participantObjectDescriptions.isEmpty())
+                getParticipantObjectDescriptions().isEmpty())
             throw new AuditException("DICOM Object Descriptions must be present for StudyInstanceUID participant object ID types");
     }
 }

--- a/commons/ihe/core/src/main/java/org/openehealth/ipf/commons/ihe/core/atna/event/DicomInstancesAccessedAuditBuilder.java
+++ b/commons/ihe/core/src/main/java/org/openehealth/ipf/commons/ihe/core/atna/event/DicomInstancesAccessedAuditBuilder.java
@@ -20,14 +20,18 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import org.openehealth.ipf.commons.audit.AuditContext;
 import org.openehealth.ipf.commons.audit.codes.EventActionCode;
 import org.openehealth.ipf.commons.audit.codes.EventOutcomeIndicator;
 import org.openehealth.ipf.commons.audit.codes.ParticipantObjectDataLifeCycle;
+import org.openehealth.ipf.commons.audit.codes.ParticipantObjectIdTypeCode;
 import org.openehealth.ipf.commons.audit.codes.ParticipantObjectTypeCode;
 import org.openehealth.ipf.commons.audit.codes.ParticipantObjectTypeCodeRole;
 import org.openehealth.ipf.commons.audit.event.DicomInstancesAccessedBuilder;
+import org.openehealth.ipf.commons.audit.model.DicomObjectDescriptionType;
+import org.openehealth.ipf.commons.audit.model.ParticipantObjectIdentificationType;
 import org.openehealth.ipf.commons.audit.model.TypeValuePairType;
 import org.openehealth.ipf.commons.audit.types.EventType;
 import org.openehealth.ipf.commons.audit.types.ParticipantObjectIdType;
@@ -114,6 +118,11 @@ public class DicomInstancesAccessedAuditBuilder<T extends DicomInstancesAccessed
                 participantObjectTypeCodeRole,
                 participantObjectDataLifeCycle,
                 null);
+        return self();
+    }
+
+    public T addTransferredStudyParticipantObject(final String studyId, final List<TypeValuePairType> objectDetails) {
+        delegate.addStudyParticipantObject(studyId, objectDetails);
         return self();
     }
 

--- a/commons/ihe/core/src/main/java/org/openehealth/ipf/commons/ihe/core/atna/event/DicomInstancesTransferredAuditBuilder.java
+++ b/commons/ihe/core/src/main/java/org/openehealth/ipf/commons/ihe/core/atna/event/DicomInstancesTransferredAuditBuilder.java
@@ -117,6 +117,11 @@ public class DicomInstancesTransferredAuditBuilder<T extends DicomInstancesTrans
         return self();
     }
 
+    public T addTransferredStudyParticipantObject(final String studyId, final List<TypeValuePairType> objectDetails) {
+        delegate.addStudyParticipantObject(studyId, objectDetails);
+        return self();
+    }
+
     @Override
     public void validate() {
         super.validate();

--- a/commons/ihe/core/src/main/java/org/openehealth/ipf/commons/ihe/core/atna/event/IHEAuditMessageBuilder.java
+++ b/commons/ihe/core/src/main/java/org/openehealth/ipf/commons/ihe/core/atna/event/IHEAuditMessageBuilder.java
@@ -50,6 +50,7 @@ public abstract class IHEAuditMessageBuilder<T extends IHEAuditMessageBuilder<T,
     public static final String REPOSITORY_UNIQUE_ID = "Repository Unique Id";
     public static final String STUDY_INSTANCE_UNIQUE_ID = "Study Instance Unique Id";
     public static final String SERIES_INSTANCE_UNIQUE_ID = "Series Instance Unique Id";
+    public static final String DOCUMENT_UNIQUE_ID = "ihe:DocumentUniqueId";
 
     private final AuditContext auditContext;
 
@@ -168,6 +169,30 @@ public abstract class IHEAuditMessageBuilder<T extends IHEAuditMessageBuilder<T,
         }
         return tvp;
     }
+
+
+    public List<TypeValuePairType> dicomDetails(String repositoryId,
+            String homeCommunityId,
+            String documentInstanceId,
+            String seriesInstanceId,
+            boolean xcaHomeCommunityId) {
+        List<TypeValuePairType> tvp = new ArrayList<>(0);
+        if (documentInstanceId != null) {
+            tvp.add(getTypeValuePair(DOCUMENT_UNIQUE_ID, documentInstanceId));
+        }
+        if (seriesInstanceId != null) {
+            tvp.add(getTypeValuePair(SERIES_INSTANCE_UNIQUE_ID, seriesInstanceId));
+        }
+        if (repositoryId != null) {
+            tvp.add(getTypeValuePair(REPOSITORY_UNIQUE_ID, repositoryId));
+        }
+        if (homeCommunityId != null) {
+            String type = xcaHomeCommunityId ? URN_IHE_ITI_XCA_2010_HOME_COMMUNITY_ID : IHE_HOME_COMMUNITY_ID;
+            tvp.add(getTypeValuePair(type, homeCommunityId));
+        }
+        return tvp;
+    }
+
 
     /**
      * @deprecated use {@link IHEAuditMessageBuilder#documentDetails(String, String, String, String, boolean)}

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/audit/event/DicomInstancesAccessedEventBuilder.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/audit/event/DicomInstancesAccessedEventBuilder.java
@@ -83,4 +83,26 @@ public class DicomInstancesAccessedEventBuilder
         return self();
     }
 
+    public DicomInstancesAccessedEventBuilder addTransferredStudy(
+            final XdsNonconstructiveDocumentSetRequestAuditDataset auditDataset,
+            final XdsNonconstructiveDocumentSetRequestAuditDataset.Status status,
+            final boolean xcaHomeCommunityId) {
+
+        final String[] documentIds = auditDataset.getDocumentIds(status);
+        final String[] homeCommunityIds = auditDataset.getHomeCommunityIds(status);
+        final String[] repositoryIds = auditDataset.getRepositoryIds(status);
+        final String[] seriesInstanceIds = auditDataset.getSeriesInstanceIds(status);
+        final String[] studyInstanceIds = auditDataset.getStudyInstanceIds(status);
+
+        for (int i = 0; i < studyInstanceIds.length; i++) {
+            addTransferredStudyParticipantObject(studyInstanceIds[i],
+                    dicomDetails(repositoryIds[i],
+                            homeCommunityIds[i],
+                            documentIds[i],
+                            seriesInstanceIds[i],
+                            xcaHomeCommunityId));
+        }
+        return self();
+    }
+
 }

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/audit/event/DicomInstancesTransferredEventBuilder.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/audit/event/DicomInstancesTransferredEventBuilder.java
@@ -65,21 +65,25 @@ public class DicomInstancesTransferredEventBuilder extends
                 documentDetails(null, auditDataset.getHomeCommunityId(), null, null, xcaHomeCommunityId));
     }
 
-    public DicomInstancesTransferredEventBuilder addDocumentIds(final XdsNonconstructiveDocumentSetRequestAuditDataset auditDataset,
+    public DicomInstancesTransferredEventBuilder addTransferredStudy(
+            final XdsNonconstructiveDocumentSetRequestAuditDataset auditDataset,
             final XdsNonconstructiveDocumentSetRequestAuditDataset.Status status,
             final boolean xcaHomeCommunityId) {
+
         final String[] documentIds = auditDataset.getDocumentIds(status);
         final String[] homeCommunityIds = auditDataset.getHomeCommunityIds(status);
         final String[] repositoryIds = auditDataset.getRepositoryIds(status);
         final String[] seriesInstanceIds = auditDataset.getSeriesInstanceIds(status);
         final String[] studyInstanceIds = auditDataset.getStudyInstanceIds(status);
-        IntStream.range(0, documentIds.length).forEach(i ->
-                addExportedEntity(
-                        documentIds[i],
-                        ParticipantObjectIdTypeCode.ReportNumber,
-                        ParticipantObjectTypeCodeRole.Report,
-                        documentDetails(repositoryIds[i], homeCommunityIds[i], seriesInstanceIds[i],
-                                studyInstanceIds[i], xcaHomeCommunityId)));
+
+        for (int i = 0; i < studyInstanceIds.length; i++) {
+            addTransferredStudyParticipantObject(studyInstanceIds[i],
+                    dicomDetails(repositoryIds[i],
+                            homeCommunityIds[i],
+                            documentIds[i],
+                            seriesInstanceIds[i],
+                            xcaHomeCommunityId));
+        }
         return self();
     }
 

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/rad69/Rad69ClientAuditStrategy.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/rad69/Rad69ClientAuditStrategy.java
@@ -60,7 +60,7 @@ public class Rad69ClientAuditStrategy extends XdsIRetrieveAuditStrategy30 {
                 EventActionCode.Create,
                 XdsEventTypeCode.RetrieveImagingDocumentSet, auditDataset.getPurposesOfUse())
                 .setPatient(auditDataset.getPatientId())
-                .addDocumentIds(auditDataset, status, false)
+                .addTransferredStudy(auditDataset, status, false)
                 .getMessage();
     }
 

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/rad69/Rad69ServerAuditStrategy.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/rad69/Rad69ServerAuditStrategy.java
@@ -60,7 +60,7 @@ public class Rad69ServerAuditStrategy extends XdsIRetrieveAuditStrategy30 {
                 EventActionCode.Read,
                 XdsEventTypeCode.RetrieveImagingDocumentSet, auditDataset.getPurposesOfUse())
                 .setPatient(auditDataset.getPatientId())
-                .addDocumentIds(auditDataset, status, false)
+                .addTransferredStudy(auditDataset, status, false)
                 .getMessage();
     }
 

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/rad75/Rad75ClientAuditStrategy.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/rad75/Rad75ClientAuditStrategy.java
@@ -60,7 +60,7 @@ public class Rad75ClientAuditStrategy extends XdsIRetrieveAuditStrategy30 {
                 EventActionCode.Create,
                 XdsEventTypeCode.CrossGatewayRetrieveImagingDocumentSet, auditDataset.getPurposesOfUse())
                 .setPatient(auditDataset.getPatientId())
-                .addDocumentIds(auditDataset, status, true)
+                .addTransferredStudy(auditDataset, status, true)
                 .getMessage();
     }
 

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/rad75/Rad75ServerAuditStrategy.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/rad75/Rad75ServerAuditStrategy.java
@@ -60,7 +60,7 @@ public class Rad75ServerAuditStrategy extends XdsIRetrieveAuditStrategy30 {
                 EventActionCode.Read,
                 XdsEventTypeCode.CrossGatewayRetrieveImagingDocumentSet, auditDataset.getPurposesOfUse())
                 .setPatient(auditDataset.getPatientId())
-                .addDocumentIds(auditDataset, status, true)
+                .addTransferredStudy(auditDataset, status, true)
                 .getMessage();
     }
 

--- a/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/atna/XdsAuditorTestBase.java
+++ b/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/atna/XdsAuditorTestBase.java
@@ -31,7 +31,7 @@ public class XdsAuditorTestBase extends AuditorTestBase {
     protected static final String[] REPOSITORY_OIDS = {"2.1.1", "2.1.2", "2.1.3"};
     protected static final String[] HOME_COMMUNITY_IDS = {"3.1.1", "3.1.2", "3.1.3"};
     protected static final String[] OBJECT_UUIDS = {"objectUuid1", "objectUuid2", "objectUuid3"};
-    protected static final String[] STUDY_INSTANCE_UUIDS = {"study-instance_uuid-1", "study-instance_uuid-1", "study-instance_uuid-2"};
+    protected static final String[] STUDY_INSTANCE_UUIDS = {"study-instance_uuid-1", "study-instance_uuid-2", "study-instance_uuid-3"};
     protected static final String[] SERIES_INSTANCE_UUIDS = {"series-instance_uuid-11", "series-instance_uuid-12", "series-instance_uuid-21"};
 
     protected void assertCommonXdsAuditAttributes(AuditMessage auditMessage,

--- a/platform-camel/ihe/xds/src/test/groovy/org/openehealth/ipf/platform/camel/ihe/xds/XdsStandardTestContainer.groovy
+++ b/platform-camel/ihe/xds/src/test/groovy/org/openehealth/ipf/platform/camel/ihe/xds/XdsStandardTestContainer.groovy
@@ -143,10 +143,10 @@ class XdsStandardTestContainer extends StandardTestContainer {
     void checkImageDocument(ParticipantObjectIdentificationType doc, String docUniqueId, String homeId, String repoId, String studyId, String seriesId) {
         assert doc.participantObjectTypeCode == ParticipantObjectTypeCode.System
         assert doc.participantObjectTypeCodeRole == ParticipantObjectTypeCodeRole.Report
-        checkCode(doc.participantObjectIDTypeCode, '9', 'RFC-3881')
-        assert doc.participantObjectID == docUniqueId
+        checkCode(doc.participantObjectIDTypeCode, '110180', 'DCM')
+        assert doc.participantObjectID == studyId
 
-        checkParticipantObjectDetail(doc.participantObjectDetails[0], IHEAuditMessageBuilder.STUDY_INSTANCE_UNIQUE_ID, studyId)
+        checkParticipantObjectDetail(doc.participantObjectDetails[0], IHEAuditMessageBuilder.DOCUMENT_UNIQUE_ID, docUniqueId)
         checkParticipantObjectDetail(doc.participantObjectDetails[1], IHEAuditMessageBuilder.SERIES_INSTANCE_UNIQUE_ID, seriesId)
         checkParticipantObjectDetail(doc.participantObjectDetails[2], IHEAuditMessageBuilder.REPOSITORY_UNIQUE_ID, repoId)
         checkParticipantObjectDetail(doc.participantObjectDetails[3], IHEAuditMessageBuilder.IHE_HOME_COMMUNITY_ID, homeId)


### PR DESCRIPTION
According the [EVSClient atna validator](https://gazelle.ihe.net/EVSClient/atna/validator.seam?standard=ATNA-IHE&extension=IHE) handling with DICOM stydies need additional ParticipantObjectIdentification.

The adapted atna log pass now the validation.

Please verify the logged data.

Example which get created by Rad69AuditStrategyTest execution
``` 
...
  <ParticipantObjectIdentification ParticipantObjectID="study-instance_uuid-1" ParticipantObjectTypeCode="2" ParticipantObjectTypeCodeRole="3">
    <ParticipantObjectIDTypeCode csd-code="110180" codeSystemName="DCM" originalText="Study Instance UID" />
    <ParticipantObjectName>study-instance_uuid-1</ParticipantObjectName>
    <ParticipantObjectDetail type="ihe:DocumentUniqueId" value="MS4xLjE=" />
    <ParticipantObjectDetail type="Series Instance Unique Id" value="c2VyaWVzLWluc3RhbmNlX3V1aWQtMTE=" />
    <ParticipantObjectDetail type="Repository Unique Id" value="Mi4xLjE=" />
    <ParticipantObjectDetail type="ihe:homeCommunityID" value="My4xLjE=" />
    <ParticipantObjectDescription>
      <ParticipantObjectContainsStudy>
        <StudyIDs UID="study-instance_uuid-1" />
      </ParticipantObjectContainsStudy>
    </ParticipantObjectDescription>
  </ParticipantObjectIdentification>
...
```

kind regards
Eugen