### PR TITLE
Add support for PHARM-1 transaction

### DIFF
--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/XDS.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/XDS.java
@@ -43,6 +43,7 @@ import org.openehealth.ipf.commons.ihe.xds.iti62.Iti62AuditStrategy;
 import org.openehealth.ipf.commons.ihe.xds.iti62.Iti62PortType;
 import org.openehealth.ipf.commons.ihe.xds.iti86.Iti86AuditStrategy;
 import org.openehealth.ipf.commons.ihe.xds.iti86.Iti86PortType;
+import org.openehealth.ipf.commons.ihe.xds.pharm1.Pharm1AuditStrategy;
 import org.openehealth.ipf.commons.ihe.xds.pharm1.Pharm1PortType;
 
 import javax.xml.namespace.QName;
@@ -243,8 +244,8 @@ public class XDS implements XdsIntegrationProfile {
             "xds-pharm1",
             "Query Pharmacy Documents",
             true,
-            new Iti18AuditStrategy(false),
-            new Iti18AuditStrategy(true),
+            new Pharm1AuditStrategy(false),
+            new Pharm1AuditStrategy(true),
             new QName("urn:ihe:iti:xds-b:2007", "CommunityPharmacyManager_Service", "ihe"),
             Pharm1PortType.class,
             new QName("urn:ihe:iti:xds-b:2007", "CommunityPharmacyManager_Binding_Soap12", "ihe"),

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/XDS.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/XDS.java
@@ -43,6 +43,7 @@ import org.openehealth.ipf.commons.ihe.xds.iti62.Iti62AuditStrategy;
 import org.openehealth.ipf.commons.ihe.xds.iti62.Iti62PortType;
 import org.openehealth.ipf.commons.ihe.xds.iti86.Iti86AuditStrategy;
 import org.openehealth.ipf.commons.ihe.xds.iti86.Iti86PortType;
+import org.openehealth.ipf.commons.ihe.xds.pharm1.Pharm1PortType;
 
 import javax.xml.namespace.QName;
 import java.util.Arrays;
@@ -245,10 +246,10 @@ public class XDS implements XdsIntegrationProfile {
             new Iti18AuditStrategy(false),
             new Iti18AuditStrategy(true),
             new QName("urn:ihe:iti:xds-b:2007", "DocumentRegistry_Service", "ihe"),
-            Iti18PortType.class,
+            Pharm1PortType.class,
             new QName("urn:ihe:iti:xds-b:2007", "DocumentRegistry_Binding_Soap12", "ihe"),
             false,
-            "wsdl/iti18.wsdl",
+            "wsdl/pharm1.wsdl",
             true,
             false,
             true,

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/XDS.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/XDS.java
@@ -66,7 +66,8 @@ public class XDS implements XdsIntegrationProfile {
         ITI_57(ITI_57_WS_CONFIG),
         ITI_61(ITI_61_WS_CONFIG),
         ITI_62(ITI_62_WS_CONFIG),
-        ITI_86(ITI_86_WS_CONFIG);
+        ITI_86(ITI_86_WS_CONFIG),
+        PHARM_1(ITI_PHARM1_WS_CONFIG);
 
         @Getter private WsTransactionConfiguration<? extends XdsAuditDataset> wsTransactionConfiguration;
 
@@ -234,6 +235,23 @@ public class XDS implements XdsIntegrationProfile {
             true,
             false,
             false,
+            false);
+
+
+    private final static WsTransactionConfiguration<XdsQueryAuditDataset> ITI_PHARM1_WS_CONFIG = new WsTransactionConfiguration<>(
+            "xds-iti18",
+            "Registry Stored Query",
+            true,
+            new Iti18AuditStrategy(false),
+            new Iti18AuditStrategy(true),
+            new QName("urn:ihe:iti:xds-b:2007", "DocumentRegistry_Service", "ihe"),
+            Iti18PortType.class,
+            new QName("urn:ihe:iti:xds-b:2007", "DocumentRegistry_Binding_Soap12", "ihe"),
+            false,
+            "wsdl/iti18.wsdl",
+            true,
+            false,
+            true,
             false);
 
 }

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/XDS.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/XDS.java
@@ -240,14 +240,14 @@ public class XDS implements XdsIntegrationProfile {
 
 
     private final static WsTransactionConfiguration<XdsQueryAuditDataset> ITI_PHARM1_WS_CONFIG = new WsTransactionConfiguration<>(
-            "xds-iti18",
-            "Registry Stored Query",
+            "xds-pharm1",
+            "Query Pharmacy Documents",
             true,
             new Iti18AuditStrategy(false),
             new Iti18AuditStrategy(true),
-            new QName("urn:ihe:iti:xds-b:2007", "DocumentRegistry_Service", "ihe"),
+            new QName("urn:ihe:iti:xds-b:2007", "CommunityPharmacyManager_Service", "ihe"),
             Pharm1PortType.class,
-            new QName("urn:ihe:iti:xds-b:2007", "DocumentRegistry_Binding_Soap12", "ihe"),
+            new QName("urn:ihe:iti:xds-b:2007", "CommunityPharmacyManager_Binding_Soap12", "ihe"),
             false,
             "wsdl/pharm1.wsdl",
             true,

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/audit/codes/XdsEventTypeCode.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/audit/codes/XdsEventTypeCode.java
@@ -44,6 +44,7 @@ public enum XdsEventTypeCode implements EventType, EnumeratedCodedValue<EventTyp
     CrossGatewayDocumentProvide("ITI-80", "CrossGatewayDocumentProvide"),
     RemoveDocuments("ITI-86", "Remove Documents"),
     RestrictedUpdateDocumentSet("ITI-92", "Restricted Update Document Set"),
+    QueryPharmacyDocuments("PHARM-1", "Query Pharmacy Documents"),
     RetrieveImagingDocumentSet("RAD-69", "Retrieve Imaging Document Set"),
     CrossGatewayRetrieveImagingDocumentSet("RAD-75", "Cross Gateway Retrieve Imaging Document Set");
 

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/audit/codes/XdsParticipantObjectIdTypeCode.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/audit/codes/XdsParticipantObjectIdTypeCode.java
@@ -31,7 +31,8 @@ public enum XdsParticipantObjectIdTypeCode implements ParticipantObjectIdType, E
     RegistryStoredQuery("ITI-18", "Registry Stored Query"),
     CrossGatewayQuery("ITI-38", "Cross Gateway Query"),
     MultiPatientStoredQuery("ITI-51", "Multi-Patient Stored Query"),
-    CrossCommunityFetch("ITI-63", "XCF Fetch");
+    CrossCommunityFetch("ITI-63", "XCF Fetch"),
+    QueryPharmacyDocuments("PHARM-1", "Query Pharmacy Documents");
 
     @Getter
     private ParticipantObjectIdType value;

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindDispensesQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindDispensesQuery.java
@@ -1,10 +1,7 @@
 package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
 
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
 
 import javax.xml.bind.annotation.*;
 
@@ -17,10 +14,8 @@ import javax.xml.bind.annotation.*;
 @XmlRootElement(name = "findDispensesQuery")
 @EqualsAndHashCode(callSuper = true, doNotUseGetters = true)
 @ToString(callSuper = true, doNotUseGetters = true)
-public class FindDispensesQuery extends StoredQuery implements PatientIdBasedStoredQuery {
+public class FindDispensesQuery extends Pharm1StableDocumentsQuery {
     private static final long serialVersionUID = -8924928000145710050L;
-
-    @Getter @Setter private Identifiable patientId;
 
     /**
      * Constructs the query.

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindDispensesQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindDispensesQuery.java
@@ -1,0 +1,36 @@
+package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
+
+import javax.xml.bind.annotation.*;
+
+/**
+ * Represents a stored query for FindDispensesQuery (PHARM-1).
+ * @author Quentin Ligier
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "FindDispensesQuery", propOrder = {})
+@XmlRootElement(name = "findDispensesQuery")
+@EqualsAndHashCode(callSuper = true, doNotUseGetters = true)
+@ToString(callSuper = true, doNotUseGetters = true)
+public class FindDispensesQuery extends StoredQuery implements PatientIdBasedStoredQuery {
+    private static final long serialVersionUID = -8924928000145710050L;
+
+    @Getter @Setter private Identifiable patientId;
+
+    /**
+     * Constructs the query.
+     */
+    public FindDispensesQuery() {
+        super(QueryType.FIND_DISPENSES);
+    }
+
+    @Override
+    public void accept(Visitor visitor) {
+        visitor.visit(this);
+    }
+}

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindMedicationAdministrationsQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindMedicationAdministrationsQuery.java
@@ -1,0 +1,36 @@
+package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
+
+import javax.xml.bind.annotation.*;
+
+/**
+ * Represents a stored query for FindMedicationAdministrationsQuery (PHARM-1).
+ * @author Quentin Ligier
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "FindMedicationAdministrationsQuery", propOrder = {})
+@XmlRootElement(name = "findMedicationAdministrationsQuery")
+@EqualsAndHashCode(callSuper = true, doNotUseGetters = true)
+@ToString(callSuper = true, doNotUseGetters = true)
+public class FindMedicationAdministrationsQuery extends StoredQuery implements PatientIdBasedStoredQuery {
+    private static final long serialVersionUID = -5233621576759064938L;
+
+    @Getter @Setter private Identifiable patientId;
+
+    /**
+     * Constructs the query.
+     */
+    public FindMedicationAdministrationsQuery() {
+        super(QueryType.FIND_MEDICATION_ADMINISTRATIONS);
+    }
+
+    @Override
+    public void accept(Visitor visitor) {
+        visitor.visit(this);
+    }
+}

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindMedicationAdministrationsQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindMedicationAdministrationsQuery.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
 
 import lombok.EqualsAndHashCode;

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindMedicationAdministrationsQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindMedicationAdministrationsQuery.java
@@ -1,10 +1,7 @@
 package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
 
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
 
 import javax.xml.bind.annotation.*;
 
@@ -17,10 +14,8 @@ import javax.xml.bind.annotation.*;
 @XmlRootElement(name = "findMedicationAdministrationsQuery")
 @EqualsAndHashCode(callSuper = true, doNotUseGetters = true)
 @ToString(callSuper = true, doNotUseGetters = true)
-public class FindMedicationAdministrationsQuery extends StoredQuery implements PatientIdBasedStoredQuery {
+public class FindMedicationAdministrationsQuery extends Pharm1StableDocumentsQuery {
     private static final long serialVersionUID = -5233621576759064938L;
-
-    @Getter @Setter private Identifiable patientId;
 
     /**
      * Constructs the query.

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindMedicationListQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindMedicationListQuery.java
@@ -1,12 +1,25 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.AvailabilityStatus;
 import org.openehealth.ipf.commons.ihe.xds.core.metadata.Code;
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
 import org.openehealth.ipf.commons.ihe.xds.core.metadata.TimeRange;
 
 import javax.xml.bind.annotation.*;
@@ -17,7 +30,7 @@ import java.util.List;
  * @author Quentin Ligier
  */
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlType(name = "FindMedicationListQuery", propOrder = {"formatCodes", "typeCodes"})
+@XmlType(name = "FindMedicationListQuery", propOrder = {"formatCodes", "typeCodes", "serviceStart", "serviceEnd"})
 @XmlRootElement(name = "findMedicationListQuery")
 @EqualsAndHashCode(callSuper = true, doNotUseGetters = true)
 @ToString(callSuper = true, doNotUseGetters = true)
@@ -28,6 +41,8 @@ public class FindMedicationListQuery extends PharmacyDocumentsQuery {
     @Getter @Setter private List<Code> formatCodes;
     @XmlElement(name = "typeCode")
     @Getter @Setter private List<Code> typeCodes;
+    @Getter private final TimeRange serviceStart = new TimeRange();
+    @Getter private final TimeRange serviceEnd = new TimeRange();
 
     /**
      * Constructs the query.

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindMedicationListQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindMedicationListQuery.java
@@ -1,0 +1,36 @@
+package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
+
+import javax.xml.bind.annotation.*;
+
+/**
+ * Represents a stored query for FindMedicationListQuery (PHARM-1).
+ * @author Quentin Ligier
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "FindMedicationListQuery", propOrder = {})
+@XmlRootElement(name = "findMedicationListQuery")
+@EqualsAndHashCode(callSuper = true, doNotUseGetters = true)
+@ToString(callSuper = true, doNotUseGetters = true)
+public class FindMedicationListQuery extends StoredQuery implements PatientIdBasedStoredQuery {
+    private static final long serialVersionUID = 7810851265303915098L;
+
+    @Getter @Setter private Identifiable patientId;
+
+    /**
+     * Constructs the query.
+     */
+    public FindMedicationListQuery() {
+        super(QueryType.FIND_MEDICATION_LIST);
+    }
+
+    @Override
+    public void accept(Visitor visitor) {
+        visitor.visit(this);
+    }
+}

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindMedicationListQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindMedicationListQuery.java
@@ -4,16 +4,22 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.AvailabilityStatus;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Code;
 import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.TimeRange;
 
 import javax.xml.bind.annotation.*;
+import java.util.List;
 
 /**
  * Represents a stored query for FindMedicationListQuery (PHARM-1).
  * @author Quentin Ligier
  */
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlType(name = "FindMedicationListQuery", propOrder = {})
+@XmlType(name = "FindMedicationListQuery", propOrder = {
+        "patientId", "serviceStartTime", "serviceStopTime", "status",
+        "formatCodes", "typeCodes", "metadataLevel"})
 @XmlRootElement(name = "findMedicationListQuery")
 @EqualsAndHashCode(callSuper = true, doNotUseGetters = true)
 @ToString(callSuper = true, doNotUseGetters = true)
@@ -21,6 +27,14 @@ public class FindMedicationListQuery extends StoredQuery implements PatientIdBas
     private static final long serialVersionUID = 7810851265303915098L;
 
     @Getter @Setter private Identifiable patientId;
+    @Getter private final TimeRange serviceStartTime = new TimeRange();
+    @Getter private final TimeRange serviceStopTime = new TimeRange();
+    @Getter @Setter private List<AvailabilityStatus> status;
+    @Getter @Setter private Integer metadataLevel;
+    @XmlElement(name = "formatCode")
+    @Getter @Setter private List<Code> formatCodes;
+    @XmlElement(name = "typeCode")
+    @Getter @Setter private List<Code> typeCodes;
 
     /**
      * Constructs the query.

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindMedicationListQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindMedicationListQuery.java
@@ -17,20 +17,13 @@ import java.util.List;
  * @author Quentin Ligier
  */
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlType(name = "FindMedicationListQuery", propOrder = {
-        "patientId", "serviceStartTime", "serviceStopTime", "status",
-        "formatCodes", "typeCodes", "metadataLevel"})
+@XmlType(name = "FindMedicationListQuery", propOrder = {"formatCodes", "typeCodes"})
 @XmlRootElement(name = "findMedicationListQuery")
 @EqualsAndHashCode(callSuper = true, doNotUseGetters = true)
 @ToString(callSuper = true, doNotUseGetters = true)
-public class FindMedicationListQuery extends StoredQuery implements PatientIdBasedStoredQuery {
+public class FindMedicationListQuery extends PharmacyDocumentsQuery {
     private static final long serialVersionUID = 7810851265303915098L;
 
-    @Getter @Setter private Identifiable patientId;
-    @Getter private final TimeRange serviceStartTime = new TimeRange();
-    @Getter private final TimeRange serviceStopTime = new TimeRange();
-    @Getter @Setter private List<AvailabilityStatus> status;
-    @Getter @Setter private Integer metadataLevel;
     @XmlElement(name = "formatCode")
     @Getter @Setter private List<Code> formatCodes;
     @XmlElement(name = "typeCode")

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindMedicationTreatmentPlansQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindMedicationTreatmentPlansQuery.java
@@ -1,10 +1,7 @@
 package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
 
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
 
 import javax.xml.bind.annotation.*;
 
@@ -17,10 +14,8 @@ import javax.xml.bind.annotation.*;
 @XmlRootElement(name = "findMedicationTreatmentPlansQuery")
 @EqualsAndHashCode(callSuper = true, doNotUseGetters = true)
 @ToString(callSuper = true, doNotUseGetters = true)
-public class FindMedicationTreatmentPlansQuery extends StoredQuery implements PatientIdBasedStoredQuery {
+public class FindMedicationTreatmentPlansQuery extends Pharm1StableDocumentsQuery {
     private static final long serialVersionUID = 5983946116420097344L;
-
-    @Getter @Setter private Identifiable patientId;
 
     /**
      * Constructs the query.

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindMedicationTreatmentPlansQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindMedicationTreatmentPlansQuery.java
@@ -1,0 +1,36 @@
+package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
+
+import javax.xml.bind.annotation.*;
+
+/**
+ * Represents a stored query for FindMedicationTreatmentPlansQuery (PHARM-1).
+ * @author Quentin Ligier
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "FindMedicationTreatmentPlansQuery", propOrder = {})
+@XmlRootElement(name = "findMedicationTreatmentPlansQuery")
+@EqualsAndHashCode(callSuper = true, doNotUseGetters = true)
+@ToString(callSuper = true, doNotUseGetters = true)
+public class FindMedicationTreatmentPlansQuery extends StoredQuery implements PatientIdBasedStoredQuery {
+    private static final long serialVersionUID = 5983946116420097344L;
+
+    @Getter @Setter private Identifiable patientId;
+
+    /**
+     * Constructs the query.
+     */
+    public FindMedicationTreatmentPlansQuery() {
+        super(QueryType.FIND_MEDICATION_TREATMENT_PLANS);
+    }
+
+    @Override
+    public void accept(Visitor visitor) {
+        visitor.visit(this);
+    }
+}

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindMedicationTreatmentPlansQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindMedicationTreatmentPlansQuery.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
 
 import lombok.EqualsAndHashCode;

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindPrescriptionsForDispenseQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindPrescriptionsForDispenseQuery.java
@@ -1,10 +1,7 @@
 package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
 
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
 
 import javax.xml.bind.annotation.*;
 
@@ -17,10 +14,8 @@ import javax.xml.bind.annotation.*;
 @XmlRootElement(name = "findPrescriptionsForDispenseQuery")
 @EqualsAndHashCode(callSuper = true, doNotUseGetters = true)
 @ToString(callSuper = true, doNotUseGetters = true)
-public class FindPrescriptionsForDispenseQuery extends StoredQuery implements PatientIdBasedStoredQuery {
+public class FindPrescriptionsForDispenseQuery extends Pharm1StableDocumentsQuery {
     private static final long serialVersionUID = -2056362879334066497L;
-
-    @Getter @Setter private Identifiable patientId;
 
     /**
      * Constructs the query.

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindPrescriptionsForDispenseQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindPrescriptionsForDispenseQuery.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
 
 import lombok.EqualsAndHashCode;

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindPrescriptionsForDispenseQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindPrescriptionsForDispenseQuery.java
@@ -1,0 +1,36 @@
+package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
+
+import javax.xml.bind.annotation.*;
+
+/**
+ * Represents a stored query for FindPrescriptionsForDispenseQuery (PHARM-1).
+ * @author Quentin Ligier
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "FindPrescriptionsForDispenseQuery", propOrder = {})
+@XmlRootElement(name = "findPrescriptionsForDispenseQuery")
+@EqualsAndHashCode(callSuper = true, doNotUseGetters = true)
+@ToString(callSuper = true, doNotUseGetters = true)
+public class FindPrescriptionsForDispenseQuery extends StoredQuery implements PatientIdBasedStoredQuery {
+    private static final long serialVersionUID = -2056362879334066497L;
+
+    @Getter @Setter private Identifiable patientId;
+
+    /**
+     * Constructs the query.
+     */
+    public FindPrescriptionsForDispenseQuery() {
+        super(QueryType.FIND_PRESCRIPTIONS_FOR_DISPENSE);
+    }
+
+    @Override
+    public void accept(Visitor visitor) {
+        visitor.visit(this);
+    }
+}

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindPrescriptionsForValidationQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindPrescriptionsForValidationQuery.java
@@ -1,0 +1,36 @@
+package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
+
+import javax.xml.bind.annotation.*;
+
+/**
+ * Represents a stored query for FindPrescriptionsForValidationQuery (PHARM-1).
+ * @author Quentin Ligier
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "FindPrescriptionsForValidationQuery", propOrder = {})
+@XmlRootElement(name = "findPrescriptionsForValidationQuery")
+@EqualsAndHashCode(callSuper = true, doNotUseGetters = true)
+@ToString(callSuper = true, doNotUseGetters = true)
+public class FindPrescriptionsForValidationQuery extends StoredQuery implements PatientIdBasedStoredQuery {
+    private static final long serialVersionUID = 1029367082044223870L;
+
+    @Getter @Setter private Identifiable patientId;
+
+    /**
+     * Constructs the query.
+     */
+    public FindPrescriptionsForValidationQuery() {
+        super(QueryType.FIND_PRESCRIPTIONS_FOR_VALIDATION);
+    }
+
+    @Override
+    public void accept(Visitor visitor) {
+        visitor.visit(this);
+    }
+}

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindPrescriptionsForValidationQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindPrescriptionsForValidationQuery.java
@@ -1,10 +1,7 @@
 package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
 
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
 
 import javax.xml.bind.annotation.*;
 
@@ -17,10 +14,8 @@ import javax.xml.bind.annotation.*;
 @XmlRootElement(name = "findPrescriptionsForValidationQuery")
 @EqualsAndHashCode(callSuper = true, doNotUseGetters = true)
 @ToString(callSuper = true, doNotUseGetters = true)
-public class FindPrescriptionsForValidationQuery extends StoredQuery implements PatientIdBasedStoredQuery {
+public class FindPrescriptionsForValidationQuery extends Pharm1StableDocumentsQuery {
     private static final long serialVersionUID = 1029367082044223870L;
-
-    @Getter @Setter private Identifiable patientId;
 
     /**
      * Constructs the query.

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindPrescriptionsForValidationQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindPrescriptionsForValidationQuery.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
 
 import lombok.EqualsAndHashCode;

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindPrescriptionsQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindPrescriptionsQuery.java
@@ -1,0 +1,36 @@
+package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
+
+import javax.xml.bind.annotation.*;
+
+/**
+ * Represents a stored query for FindPrescriptionsQuery (PHARM-1).
+ * @author Quentin Ligier
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "FindPrescriptionsQuery", propOrder = {})
+@XmlRootElement(name = "findPrescriptionsQuery")
+@EqualsAndHashCode(callSuper = true, doNotUseGetters = true)
+@ToString(callSuper = true, doNotUseGetters = true)
+public class FindPrescriptionsQuery extends StoredQuery implements PatientIdBasedStoredQuery {
+    private static final long serialVersionUID = -3448220074327935334L;
+
+    @Getter @Setter private Identifiable patientId;
+
+    /**
+     * Constructs the query.
+     */
+    public FindPrescriptionsQuery() {
+        super(QueryType.FIND_PRESCRIPTIONS);
+    }
+
+    @Override
+    public void accept(Visitor visitor) {
+        visitor.visit(this);
+    }
+}

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindPrescriptionsQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindPrescriptionsQuery.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
 
 import lombok.EqualsAndHashCode;

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindPrescriptionsQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/FindPrescriptionsQuery.java
@@ -1,10 +1,7 @@
 package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
 
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
 
 import javax.xml.bind.annotation.*;
 
@@ -17,10 +14,8 @@ import javax.xml.bind.annotation.*;
 @XmlRootElement(name = "findPrescriptionsQuery")
 @EqualsAndHashCode(callSuper = true, doNotUseGetters = true)
 @ToString(callSuper = true, doNotUseGetters = true)
-public class FindPrescriptionsQuery extends StoredQuery implements PatientIdBasedStoredQuery {
+public class FindPrescriptionsQuery extends Pharm1StableDocumentsQuery {
     private static final long serialVersionUID = -3448220074327935334L;
-
-    @Getter @Setter private Identifiable patientId;
 
     /**
      * Constructs the query.

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/Pharm1StableDocumentsQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/Pharm1StableDocumentsQuery.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.*;
+import org.openehealth.ipf.commons.ihe.xds.core.transform.requests.query.QuerySlotHelper;
+
+import javax.xml.bind.annotation.*;
+import java.util.List;
+
+/**
+ * Abstract stored query for PHARM-1 stable documents queries.
+ * @author Quentin Ligier
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Pharm1StableDocumentsQuery", propOrder = {
+        "authorPersons", "creationTime", "serviceStartTime", "serviceStopTime",
+        "patientId", "confidentialityCodes", "eventCodes", "uuids",
+        "healthcareFacilityTypeCodes", "practiceSettingCodes", "uniqueIds",
+        "status", "metadataLevel"})
+@XmlRootElement(name = "abstractPharm1StableDocumentsQuery")
+@EqualsAndHashCode(callSuper = true, doNotUseGetters = true)
+@ToString(callSuper = true, doNotUseGetters = true)
+public abstract class Pharm1StableDocumentsQuery extends StoredQuery implements PatientIdBasedStoredQuery {
+    private static final long serialVersionUID = 7497052735222205532L;
+
+    @Getter @Setter private Identifiable patientId;
+    @XmlElement(name = "uuid")
+    @Getter @Setter private List<String> uuids;
+    @XmlElement(name = "uniqueId")
+    @Getter @Setter private List<String> uniqueIds;
+    @XmlElement(name = "practiceSettingCode")
+    @Getter @Setter private List<Code> practiceSettingCodes;
+    @Getter private final TimeRange creationTime = new TimeRange();
+    @Getter private final TimeRange serviceStartTime = new TimeRange();
+    @Getter private final TimeRange serviceStopTime = new TimeRange();
+    @XmlElement(name = "healthcareFacilityTypeCode")
+    @Getter @Setter private List<Code> healthcareFacilityTypeCodes;
+    @XmlElement(name = "eventCode")
+    @Getter @Setter private QueryList<Code> eventCodes;
+    @XmlElement(name = "confidentialityCode")
+    @Getter @Setter private QueryList<Code> confidentialityCodes;
+    @XmlElement(name = "authorPerson")
+    @Getter @Setter private List<String> authorPersons;
+    @Getter @Setter private List<AvailabilityStatus> status;
+    @Getter @Setter private Integer metadataLevel;
+
+    /**
+     * For JAXB serialization only.
+     */
+    public Pharm1StableDocumentsQuery() {
+    }
+
+    /**
+     * Constructs the query.
+     * @param queryType
+     *          the type of the query.
+     */
+    protected Pharm1StableDocumentsQuery(final QueryType queryType) {
+        super(queryType);
+    }
+
+    /**
+     * Allows to use a collection of {@link Person} instead of a collection of {@link String}
+     * for specifying the query parameter "$XDSDocumentEntryAuthorPerson".
+     *
+     * @param authorPersons a collection of {@link Person} objects.
+     */
+    public void setTypedAuthorPersons(List<Person> authorPersons) {
+        this.authorPersons = QuerySlotHelper.render(authorPersons);
+    }
+
+    /**
+     * Tries to return the query parameter "$XDSDocumentEntryAuthorPerson"
+     * as a collection of {@link Person} instead of a collection of {@link String}.
+     * This may fail if SQL LIKE wildcards ("%", "_", etc.) are used in one or more elements.
+     *
+     * @return a collection of {@link Person} objects.
+     */
+    public List<Person> getTypedAuthorPersons() {
+        return QuerySlotHelper.parse(this.authorPersons, Person.class);
+    }
+
+    /**
+     * FMTP  FindMedicationTreatmentPlans
+     * FP    FindPrescriptions
+     * FD    FindDispenses
+     * FMA   FindMedicationAdministrations
+     * FPV   FindPrescriptionsForValidation
+     * FPD   FindPrescriptionsForDispense
+     * FML   FindMedicationList
+     */
+    // PatientId                  x FMTP FP FD FMA FPV FPD FML
+    // EntryUUID                  x FMTP FP FD FMA FPV FPD
+    // UniqueId                   x FMTP FP FD FMA FPV FPD
+    // PracticeSettingCode        x FMTP FP FD FMA FPV FPD
+    // CreationTime               x FMTP FP FD FMA FPV FPD
+    // ServiceStartTime           x FMTP FP FD FMA FPV FPD FML
+    // ServiceStopTime            x FMTP FP FD FMA FPV FPD FML
+    // HealthcareFacilityTypeCode x FMTP FP FD FMA FPV FPD
+    // EventCodeList              x FMTP FP FD FMA FPV FPD
+    // ConfidentialityCode        x FMTP FP FD FMA FPV FPD
+    // AuthorPerson               x FMTP FP FD FMA FPV FPD
+    // Status                     x FMTP FP FD FMA FPV FPD FML
+    // MetadataLevel              x FMTP FP FD FMA FPV FPD FML
+    // FormatCode                   FML
+    // Type                         FML
+
+}

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/Pharm1StableDocumentsQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/Pharm1StableDocumentsQuery.java
@@ -93,31 +93,4 @@ public abstract class Pharm1StableDocumentsQuery extends PharmacyDocumentsQuery 
     public List<Person> getTypedAuthorPersons() {
         return QuerySlotHelper.parse(this.authorPersons, Person.class);
     }
-
-    // TODO:QLIG
-    /**
-     * FMTP  FindMedicationTreatmentPlans
-     * FP    FindPrescriptions
-     * FD    FindDispenses
-     * FMA   FindMedicationAdministrations
-     * FPV   FindPrescriptionsForValidation
-     * FPD   FindPrescriptionsForDispense
-     * FML   FindMedicationList
-     */
-    // PatientId                  x FMTP FP FD FMA FPV FPD FML
-    // EntryUUID                  x FMTP FP FD FMA FPV FPD
-    // UniqueId                   x FMTP FP FD FMA FPV FPD
-    // PracticeSettingCode        x FMTP FP FD FMA FPV FPD
-    // CreationTime               x FMTP FP FD FMA FPV FPD
-    // ServiceStartTime           x FMTP FP FD FMA FPV FPD FML
-    // ServiceStopTime            x FMTP FP FD FMA FPV FPD FML
-    // HealthcareFacilityTypeCode x FMTP FP FD FMA FPV FPD
-    // EventCodeList              x FMTP FP FD FMA FPV FPD
-    // ConfidentialityCode        x FMTP FP FD FMA FPV FPD
-    // AuthorPerson               x FMTP FP FD FMA FPV FPD
-    // Status                     x FMTP FP FD FMA FPV FPD FML
-    // MetadataLevel              x FMTP FP FD FMA FPV FPD FML
-    // FormatCode                   FML
-    // Type                         FML
-
 }

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/Pharm1StableDocumentsQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/Pharm1StableDocumentsQuery.java
@@ -31,17 +31,14 @@ import java.util.List;
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "Pharm1StableDocumentsQuery", propOrder = {
-        "authorPersons", "creationTime", "serviceStartTime", "serviceStopTime",
-        "patientId", "confidentialityCodes", "eventCodes", "uuids",
-        "healthcareFacilityTypeCodes", "practiceSettingCodes", "uniqueIds",
-        "status", "metadataLevel"})
+        "authorPersons", "creationTime", "confidentialityCodes", "eventCodes",
+        "uuids", "healthcareFacilityTypeCodes", "practiceSettingCodes", "uniqueIds"})
 @XmlRootElement(name = "abstractPharm1StableDocumentsQuery")
 @EqualsAndHashCode(callSuper = true, doNotUseGetters = true)
 @ToString(callSuper = true, doNotUseGetters = true)
-public abstract class Pharm1StableDocumentsQuery extends StoredQuery implements PatientIdBasedStoredQuery {
+public abstract class Pharm1StableDocumentsQuery extends PharmacyDocumentsQuery {
     private static final long serialVersionUID = 7497052735222205532L;
 
-    @Getter @Setter private Identifiable patientId;
     @XmlElement(name = "uuid")
     @Getter @Setter private List<String> uuids;
     @XmlElement(name = "uniqueId")
@@ -49,8 +46,6 @@ public abstract class Pharm1StableDocumentsQuery extends StoredQuery implements 
     @XmlElement(name = "practiceSettingCode")
     @Getter @Setter private List<Code> practiceSettingCodes;
     @Getter private final TimeRange creationTime = new TimeRange();
-    @Getter private final TimeRange serviceStartTime = new TimeRange();
-    @Getter private final TimeRange serviceStopTime = new TimeRange();
     @XmlElement(name = "healthcareFacilityTypeCode")
     @Getter @Setter private List<Code> healthcareFacilityTypeCodes;
     @XmlElement(name = "eventCode")
@@ -59,8 +54,6 @@ public abstract class Pharm1StableDocumentsQuery extends StoredQuery implements 
     @Getter @Setter private QueryList<Code> confidentialityCodes;
     @XmlElement(name = "authorPerson")
     @Getter @Setter private List<String> authorPersons;
-    @Getter @Setter private List<AvailabilityStatus> status;
-    @Getter @Setter private Integer metadataLevel;
 
     /**
      * For JAXB serialization only.

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/Pharm1StableDocumentsQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/Pharm1StableDocumentsQuery.java
@@ -31,8 +31,9 @@ import java.util.List;
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "Pharm1StableDocumentsQuery", propOrder = {
-        "authorPersons", "creationTime", "confidentialityCodes", "eventCodes",
-        "uuids", "healthcareFacilityTypeCodes", "practiceSettingCodes", "uniqueIds"})
+        "authorPersons", "creationTime", "serviceStartTime", "serviceStopTime",
+        "confidentialityCodes", "eventCodes", "uuids", "healthcareFacilityTypeCodes",
+        "practiceSettingCodes", "uniqueIds"})
 @XmlRootElement(name = "abstractPharm1StableDocumentsQuery")
 @EqualsAndHashCode(callSuper = true, doNotUseGetters = true)
 @ToString(callSuper = true, doNotUseGetters = true)
@@ -46,6 +47,8 @@ public abstract class Pharm1StableDocumentsQuery extends PharmacyDocumentsQuery 
     @XmlElement(name = "practiceSettingCode")
     @Getter @Setter private List<Code> practiceSettingCodes;
     @Getter private final TimeRange creationTime = new TimeRange();
+    @Getter private final TimeRange serviceStartTime = new TimeRange();
+    @Getter private final TimeRange serviceStopTime = new TimeRange();
     @XmlElement(name = "healthcareFacilityTypeCode")
     @Getter @Setter private List<Code> healthcareFacilityTypeCodes;
     @XmlElement(name = "eventCode")

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/Pharm1StableDocumentsQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/Pharm1StableDocumentsQuery.java
@@ -98,6 +98,7 @@ public abstract class Pharm1StableDocumentsQuery extends StoredQuery implements 
         return QuerySlotHelper.parse(this.authorPersons, Person.class);
     }
 
+    // TODO:QLIG
     /**
      * FMTP  FindMedicationTreatmentPlans
      * FP    FindPrescriptions

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/PharmacyDocumentsQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/PharmacyDocumentsQuery.java
@@ -1,0 +1,50 @@
+package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.AvailabilityStatus;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.TimeRange;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import java.util.List;
+
+/**
+ * Base class for Pharmacy Documents Queries (PHARM-1).
+ * @author Quentin Ligier
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "PharmacyDocumentsQuery", propOrder = {
+        "patientId", "serviceStartTime", "serviceStopTime", "status", "metadataLevel" })
+@XmlRootElement(name = "pharmacyDocumentsQuery")
+@EqualsAndHashCode(callSuper = true, doNotUseGetters = true)
+@ToString(callSuper = true, doNotUseGetters = true)
+public abstract class PharmacyDocumentsQuery extends StoredQuery implements PatientIdBasedStoredQuery {
+    private static final long serialVersionUID = -4878731956719028791L;
+
+    @Getter @Setter private Identifiable patientId;
+    @Getter private final TimeRange serviceStartTime = new TimeRange();
+    @Getter private final TimeRange serviceStopTime = new TimeRange();
+    @Getter @Setter private List<AvailabilityStatus> status;
+    @Getter @Setter private Integer metadataLevel;
+
+    /**
+     * For JAXB serialization only.
+     */
+    public PharmacyDocumentsQuery() {
+    }
+
+    /**
+     * Constructs the query.
+     * @param queryType
+     *          the type of the query.
+     */
+    protected PharmacyDocumentsQuery(final QueryType queryType) {
+        super(queryType);
+    }
+}

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/PharmacyDocumentsQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/PharmacyDocumentsQuery.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openehealth.ipf.commons.ihe.xds.core.requests.query;
 
 import lombok.EqualsAndHashCode;
@@ -6,7 +21,6 @@ import lombok.Setter;
 import lombok.ToString;
 import org.openehealth.ipf.commons.ihe.xds.core.metadata.AvailabilityStatus;
 import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.TimeRange;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -20,7 +34,7 @@ import java.util.List;
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "PharmacyDocumentsQuery", propOrder = {
-        "patientId", "serviceStartTime", "serviceStopTime", "status", "metadataLevel" })
+        "patientId", "status", "metadataLevel" })
 @XmlRootElement(name = "pharmacyDocumentsQuery")
 @EqualsAndHashCode(callSuper = true, doNotUseGetters = true)
 @ToString(callSuper = true, doNotUseGetters = true)
@@ -28,8 +42,6 @@ public abstract class PharmacyDocumentsQuery extends StoredQuery implements Pati
     private static final long serialVersionUID = -4878731956719028791L;
 
     @Getter @Setter private Identifiable patientId;
-    @Getter private final TimeRange serviceStartTime = new TimeRange();
-    @Getter private final TimeRange serviceStopTime = new TimeRange();
     @Getter @Setter private List<AvailabilityStatus> status;
     @Getter @Setter private Integer metadataLevel;
 

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/Query.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/Query.java
@@ -75,7 +75,13 @@ public abstract class Query implements Serializable {
         void visit(FindSubmissionSetsQuery query);
         void visit(FetchQuery query);
         void visit(FindDocumentsByReferenceIdQuery query);
-        // TODO
+        void visit(FindMedicationTreatmentPlansQuery query);
+        void visit(FindPrescriptionsQuery query);
+        void visit(FindDispensesQuery query);
+        void visit(FindMedicationAdministrationsQuery query);
+        void visit(FindPrescriptionsForValidationQuery query);
+        void visit(FindPrescriptionsForDispenseQuery query);
+        void visit(FindMedicationListQuery query);
     }
     
     /**

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/Query.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/Query.java
@@ -75,6 +75,7 @@ public abstract class Query implements Serializable {
         void visit(FindSubmissionSetsQuery query);
         void visit(FetchQuery query);
         void visit(FindDocumentsByReferenceIdQuery query);
+        // TODO
     }
     
     /**

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/QueryReturnType.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/QueryReturnType.java
@@ -32,6 +32,7 @@ public enum QueryReturnType {
     // for ITI-18, ITI-38 and ITI-51
     @XmlEnumValue("LeafClass") LEAF_CLASS("LeafClass"),
     @XmlEnumValue("ObjectRef") OBJECT_REF("ObjectRef"),
+    // TODO
 
     // for ITI-63
     @XmlEnumValue("LeafClassWithRepositoryItem") LEAF_CLASS_WITH_REPOSITORY_ITEM("LeafClassWithRepositoryItem");

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/QueryReturnType.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/QueryReturnType.java
@@ -23,16 +23,15 @@ import javax.xml.bind.annotation.XmlEnumValue;
 import javax.xml.bind.annotation.XmlType;
 
 /**
- * Return types for XDS queries (ITI-18, ITI-38, ITI-51, ITI-63).
+ * Return types for XDS queries (ITI-18, ITI-38, ITI-51, ITI-63, PHARM-1).
  * @author Dmytro Rud
  */
 @XmlType(name = "QueryReturnType")
 @XmlEnum(String.class)
 public enum QueryReturnType {
-    // for ITI-18, ITI-38 and ITI-51
+    // for ITI-18, ITI-38, ITI-51 and PHARM-1
     @XmlEnumValue("LeafClass") LEAF_CLASS("LeafClass"),
     @XmlEnumValue("ObjectRef") OBJECT_REF("ObjectRef"),
-    // TODO
 
     // for ITI-63
     @XmlEnumValue("LeafClassWithRepositoryItem") LEAF_CLASS_WITH_REPOSITORY_ITEM("LeafClassWithRepositoryItem");

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/QueryType.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/QueryType.java
@@ -26,6 +26,7 @@ import javax.xml.bind.annotation.XmlType;
  * All possible query types.
  * @author Jens Riemschneider
  * @author Michael Ottati
+ * @author Quentin Ligier
  */
 @XmlType(name = "QueryType")
 @XmlEnum
@@ -63,8 +64,21 @@ public enum QueryType {
     /** Returns all documents with a given relation to a specified entry. */
     @XmlEnumValue("GetRelatedDocuments") GET_RELATED_DOCUMENTS("urn:uuid:d90e5407-b356-4d91-a89f-873917b4b0e6", GetRelatedDocumentsQuery.class),
     /** Cross-Community Fetch query (ITI-63). */
-    @XmlEnumValue("Fetch") FETCH("urn:uuid:f2072993-9478-41df-a603-8f016706efe8", FetchQuery.class);
-    // TODO
+    @XmlEnumValue("Fetch") FETCH("urn:uuid:f2072993-9478-41df-a603-8f016706efe8", FetchQuery.class),
+    /** Find planned medication documents and their related documents (PHARM-1). */
+    @XmlEnumValue("FindMedicationTreatmentPlans") FIND_MEDICATION_TREATMENT_PLANS("urn:uuid:c85f5ade-81c1-44b6-8f7c-48b9cd6b9489", FindMedicationTreatmentPlansQuery.class),
+    /** Find prescriptions and their related documents (PHARM-1). */
+    @XmlEnumValue("FindPrescriptions") FIND_PRESCRIPTIONS("urn:uuid:0e6095c5-dc3d-47d9-a219-047064086d92", FindPrescriptionsQuery.class),
+    /** Find dispense documents and their related documents (PHARM-1). */
+    @XmlEnumValue("FindDispenses") FIND_DISPENSES("urn:uuid:ac79c7c7-f21b-4c88-ab81-57e4889e8758", FindDispensesQuery.class),
+    /** Find administered medication documents and their related documents (PHARM-1). */
+    @XmlEnumValue("FindMedicationAdministrations") FIND_MEDICATION_ADMINISTRATIONS("urn:uuid:fdbe8fb8-7b5c-4470-9383-8abc7135f462", FindMedicationAdministrationsQuery.class),
+    /** Find prescriptions and their related documents containing Prescription Items ready to be validated (PHARM-1). */
+    @XmlEnumValue("FindPrescriptionsForValidation") FIND_PRESCRIPTIONS_FOR_VALIDATION("urn:uuid:c1a43b20-0254-102e-8469-a6af440562e8", FindPrescriptionsForValidationQuery.class),
+    /** Find prescriptions and their related documents containing Prescription Items ready to be dispensed (PHARM-1). */
+    @XmlEnumValue("FindPrescriptionsForDispense") FIND_PRESCRIPTIONS_FOR_DISPENSE("urn:uuid:c875eb9c-0254-102e-8469-a6af440562e8", FindPrescriptionsForDispenseQuery.class),
+    /** Find the medication list to the patient (PHARM-1). */
+    @XmlEnumValue("FindMedicationList") FIND_MEDICATION_LIST("urn:uuid:80ebbd83-53c1-4453-9860-349585962af6", FindMedicationListQuery.class);
 
     private final String id;
     private final Class<? extends Query> type; 

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/QueryType.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/QueryType.java
@@ -64,6 +64,7 @@ public enum QueryType {
     @XmlEnumValue("GetRelatedDocuments") GET_RELATED_DOCUMENTS("urn:uuid:d90e5407-b356-4d91-a89f-873917b4b0e6", GetRelatedDocumentsQuery.class),
     /** Cross-Community Fetch query (ITI-63). */
     @XmlEnumValue("Fetch") FETCH("urn:uuid:f2072993-9478-41df-a603-8f016706efe8", FetchQuery.class);
+    // TODO
 
     private final String id;
     private final Class<? extends Query> type; 

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/FromEbXMLVisitor.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/FromEbXMLVisitor.java
@@ -123,4 +123,39 @@ final class FromEbXMLVisitor implements Visitor {
     public void visit(FindDocumentsByReferenceIdQuery query) {
         new FindDocumentsByReferenceIdQueryTransformer().fromEbXML(query, ebXML);
     }
+
+    @Override
+    public void visit(FindMedicationTreatmentPlansQuery query) {
+        new FindMedicationTreatmentPlansQueryTransformer().fromEbXML(query, ebXML);
+    }
+
+    @Override
+    public void visit(FindPrescriptionsQuery query) {
+        new FindPrescriptionsQueryTransformer().fromEbXML(query, ebXML);
+    }
+
+    @Override
+    public void visit(FindDispensesQuery query) {
+        new FindDispensesQueryTransformer().fromEbXML(query, ebXML);
+    }
+
+    @Override
+    public void visit(FindMedicationAdministrationsQuery query) {
+        new FindMedicationAdministrationsQueryTransformer().fromEbXML(query, ebXML);
+    }
+
+    @Override
+    public void visit(FindPrescriptionsForValidationQuery query) {
+        new FindPrescriptionsForValidationQueryTransformer().fromEbXML(query, ebXML);
+    }
+
+    @Override
+    public void visit(FindPrescriptionsForDispenseQuery query) {
+        new FindPrescriptionsForDispenseQueryTransformer().fromEbXML(query, ebXML);
+    }
+
+    @Override
+    public void visit(FindMedicationListQuery query) {
+        new FindMedicationListQueryTransformer().fromEbXML(query, ebXML);
+    }
 }

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/QueryParameter.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/QueryParameter.java
@@ -82,6 +82,14 @@ public enum QueryParameter {
     DOC_ENTRY_DOCUMENT_AVAILABILITY("$XDSDocumentEntryDocumentAvailability"),
     /** Used to filter {@link DocumentEntry#logicalUuid}. */
     DOC_ENTRY_LOGICAL_ID("$XDSDocumentEntryLogicalID"),
+    /** Used to filter {@link DocumentEntry#getServiceStartTime()}. */
+    DOC_ENTRY_SERVICE_START_FROM("$XDSDocumentEntryServiceStartFrom"),
+    /** Used to filter {@link DocumentEntry#getServiceStartTime()}. */
+    DOC_ENTRY_SERVICE_START_TO("$XDSDocumentEntryServiceStartTo"),
+    /** Used to filter {@link DocumentEntry#getServiceStopTime()}. */
+    DOC_ENTRY_SERVICE_END_FROM("$XDSDocumentEntryServiceEndFrom"),
+    /** Used to filter {@link DocumentEntry#getServiceStopTime()}. */
+    DOC_ENTRY_SERVICE_END_TO("$XDSDocumentEntryServiceEndTo"),
      
     /** Used to filter {@link Folder#getCodeList()}. */
     FOLDER_CODES("$XDSFolderCodeList"),

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/ToEbXMLVisitor.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/ToEbXMLVisitor.java
@@ -123,4 +123,39 @@ final class ToEbXMLVisitor implements Visitor {
     public void visit(FindDocumentsByReferenceIdQuery query) {
         new FindDocumentsByReferenceIdQueryTransformer().toEbXML(query, ebXML);
     }
+
+    @Override
+    public void visit(FindMedicationTreatmentPlansQuery query) {
+        new FindMedicationTreatmentPlansQueryTransformer().toEbXML(query, ebXML);
+    }
+
+    @Override
+    public void visit(FindPrescriptionsQuery query) {
+        new FindPrescriptionsQueryTransformer().toEbXML(query, ebXML);
+    }
+
+    @Override
+    public void visit(FindDispensesQuery query) {
+        new FindDispensesQueryTransformer().toEbXML(query, ebXML);
+    }
+
+    @Override
+    public void visit(FindMedicationAdministrationsQuery query) {
+        new FindMedicationAdministrationsQueryTransformer().toEbXML(query, ebXML);
+    }
+
+    @Override
+    public void visit(FindPrescriptionsForValidationQuery query) {
+        new FindPrescriptionsForValidationQueryTransformer().toEbXML(query, ebXML);
+    }
+
+    @Override
+    public void visit(FindPrescriptionsForDispenseQuery query) {
+        new FindPrescriptionsForDispenseQueryTransformer().toEbXML(query, ebXML);
+    }
+
+    @Override
+    public void visit(FindMedicationListQuery query) {
+        new FindMedicationListQueryTransformer().toEbXML(query, ebXML);
+    }
 }

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/DocumentsQueryTransformer.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/DocumentsQueryTransformer.java
@@ -44,7 +44,7 @@ abstract class DocumentsQueryTransformer<T extends DocumentsQuery> extends Abstr
         super.toEbXML(query, ebXML);
 
         QuerySlotHelper slots = new QuerySlotHelper(ebXML);
-        
+
         slots.fromStringList(DOC_ENTRY_AUTHOR_PERSON, query.getAuthorPersons());
 
         slots.fromNumber(DOC_ENTRY_CREATION_TIME_FROM, toHL7(query.getCreationTime().getFrom()));
@@ -82,7 +82,7 @@ abstract class DocumentsQueryTransformer<T extends DocumentsQuery> extends Abstr
         super.fromEbXML(query, ebXML);
 
         QuerySlotHelper slots = new QuerySlotHelper(ebXML);
-        
+
         query.setClassCodes(slots.toCodeList(DOC_ENTRY_CLASS_CODE));
         query.setTypeCodes(slots.toCodeList(DOC_ENTRY_TYPE_CODE));
         query.setPracticeSettingCodes(slots.toCodeList(DOC_ENTRY_PRACTICE_SETTING_CODE));

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/FindDispensesQueryTransformer.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/FindDispensesQueryTransformer.java
@@ -15,61 +15,12 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.transform.requests.query;
 
-import static org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryParameter.*;
-
 import org.openehealth.ipf.commons.ihe.xds.core.ebxml.EbXMLAdhocQueryRequest;
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.Hl7v2Based;
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
 import org.openehealth.ipf.commons.ihe.xds.core.requests.query.FindDispensesQuery;
 
 /**
  * Transforms between {@link FindDispensesQuery} and {@link EbXMLAdhocQueryRequest}.
  * @author Quentin Ligier
  */
-public class FindDispensesQueryTransformer extends AbstractStoredQueryTransformer<FindDispensesQuery> {
-
-    /**
-     * Transforms the query into its EbXML representation.
-     * <p>
-     * Does not perform any transformation if one of the parameters is <code>null</code>.
-     * @param query
-     *          the query to transform.
-     * @param ebXML
-     *          the EbXML representation.
-     */
-    @Override
-    public void toEbXML(FindDispensesQuery query, EbXMLAdhocQueryRequest ebXML) {
-        if (query == null || ebXML == null) {
-            return;
-        }
-
-        super.toEbXML(query, ebXML);
-
-        QuerySlotHelper slots = new QuerySlotHelper(ebXML);
-
-        slots.fromString(SUBMISSION_SET_PATIENT_ID, Hl7v2Based.render(query.getPatientId()));
-    }
-
-    /**
-     * Transforms the ebXML representation of a query into a query object.
-     * <p>
-     * Does not perform any transformation if one of the parameters is <code>null</code>.
-     * @param query
-     *          the query. Can be <code>null</code>.
-     * @param ebXML
-     *          the ebXML representation. Can be <code>null</code>.
-     */
-    @Override
-    public void fromEbXML(FindDispensesQuery query, EbXMLAdhocQueryRequest ebXML) {
-        if (query == null || ebXML == null) {
-            return;
-        }
-
-        super.fromEbXML(query, ebXML);
-
-        QuerySlotHelper slots = new QuerySlotHelper(ebXML);
-
-        String patientId = slots.toString(SUBMISSION_SET_PATIENT_ID);
-        query.setPatientId(Hl7v2Based.parse(patientId, Identifiable.class));
-    }
+public class FindDispensesQueryTransformer extends Pharm1StableDocumentsQueryTransformer<FindDispensesQuery> {
 }

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/FindDispensesQueryTransformer.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/FindDispensesQueryTransformer.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openehealth.ipf.commons.ihe.xds.core.transform.requests.query;
+
+import static org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryParameter.*;
+
+import org.openehealth.ipf.commons.ihe.xds.core.ebxml.EbXMLAdhocQueryRequest;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Hl7v2Based;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.query.FindDispensesQuery;
+
+/**
+ * Transforms between {@link FindDispensesQuery} and {@link EbXMLAdhocQueryRequest}.
+ * @author Quentin Ligier
+ */
+public class FindDispensesQueryTransformer extends AbstractStoredQueryTransformer<FindDispensesQuery> {
+
+    /**
+     * Transforms the query into its EbXML representation.
+     * <p>
+     * Does not perform any transformation if one of the parameters is <code>null</code>.
+     * @param query
+     *          the query to transform.
+     * @param ebXML
+     *          the EbXML representation.
+     */
+    @Override
+    public void toEbXML(FindDispensesQuery query, EbXMLAdhocQueryRequest ebXML) {
+        if (query == null || ebXML == null) {
+            return;
+        }
+
+        super.toEbXML(query, ebXML);
+
+        QuerySlotHelper slots = new QuerySlotHelper(ebXML);
+
+        slots.fromString(SUBMISSION_SET_PATIENT_ID, Hl7v2Based.render(query.getPatientId()));
+    }
+
+    /**
+     * Transforms the ebXML representation of a query into a query object.
+     * <p>
+     * Does not perform any transformation if one of the parameters is <code>null</code>.
+     * @param query
+     *          the query. Can be <code>null</code>.
+     * @param ebXML
+     *          the ebXML representation. Can be <code>null</code>.
+     */
+    @Override
+    public void fromEbXML(FindDispensesQuery query, EbXMLAdhocQueryRequest ebXML) {
+        if (query == null || ebXML == null) {
+            return;
+        }
+
+        super.fromEbXML(query, ebXML);
+
+        QuerySlotHelper slots = new QuerySlotHelper(ebXML);
+
+        String patientId = slots.toString(SUBMISSION_SET_PATIENT_ID);
+        query.setPatientId(Hl7v2Based.parse(patientId, Identifiable.class));
+    }
+}

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/FindMedicationAdministrationsQueryTransformer.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/FindMedicationAdministrationsQueryTransformer.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openehealth.ipf.commons.ihe.xds.core.transform.requests.query;
+
+import static org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryParameter.*;
+
+import org.openehealth.ipf.commons.ihe.xds.core.ebxml.EbXMLAdhocQueryRequest;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Hl7v2Based;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.query.FindMedicationAdministrationsQuery;
+
+/**
+ * Transforms between {@link FindMedicationAdministrationsQuery} and {@link EbXMLAdhocQueryRequest}.
+ * @author Quentin Ligier
+ */
+public class FindMedicationAdministrationsQueryTransformer extends AbstractStoredQueryTransformer<FindMedicationAdministrationsQuery> {
+
+    /**
+     * Transforms the query into its EbXML representation.
+     * <p>
+     * Does not perform any transformation if one of the parameters is <code>null</code>.
+     * @param query
+     *          the query to transform.
+     * @param ebXML
+     *          the EbXML representation.
+     */
+    @Override
+    public void toEbXML(FindMedicationAdministrationsQuery query, EbXMLAdhocQueryRequest ebXML) {
+        if (query == null || ebXML == null) {
+            return;
+        }
+
+        super.toEbXML(query, ebXML);
+
+        QuerySlotHelper slots = new QuerySlotHelper(ebXML);
+
+        slots.fromString(SUBMISSION_SET_PATIENT_ID, Hl7v2Based.render(query.getPatientId()));
+    }
+
+    /**
+     * Transforms the ebXML representation of a query into a query object.
+     * <p>
+     * Does not perform any transformation if one of the parameters is <code>null</code>.
+     * @param query
+     *          the query. Can be <code>null</code>.
+     * @param ebXML
+     *          the ebXML representation. Can be <code>null</code>.
+     */
+    @Override
+    public void fromEbXML(FindMedicationAdministrationsQuery query, EbXMLAdhocQueryRequest ebXML) {
+        if (query == null || ebXML == null) {
+            return;
+        }
+
+        super.fromEbXML(query, ebXML);
+
+        QuerySlotHelper slots = new QuerySlotHelper(ebXML);
+
+        String patientId = slots.toString(SUBMISSION_SET_PATIENT_ID);
+        query.setPatientId(Hl7v2Based.parse(patientId, Identifiable.class));
+    }
+}

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/FindMedicationAdministrationsQueryTransformer.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/FindMedicationAdministrationsQueryTransformer.java
@@ -15,61 +15,12 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.transform.requests.query;
 
-import static org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryParameter.*;
-
 import org.openehealth.ipf.commons.ihe.xds.core.ebxml.EbXMLAdhocQueryRequest;
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.Hl7v2Based;
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
 import org.openehealth.ipf.commons.ihe.xds.core.requests.query.FindMedicationAdministrationsQuery;
 
 /**
  * Transforms between {@link FindMedicationAdministrationsQuery} and {@link EbXMLAdhocQueryRequest}.
  * @author Quentin Ligier
  */
-public class FindMedicationAdministrationsQueryTransformer extends AbstractStoredQueryTransformer<FindMedicationAdministrationsQuery> {
-
-    /**
-     * Transforms the query into its EbXML representation.
-     * <p>
-     * Does not perform any transformation if one of the parameters is <code>null</code>.
-     * @param query
-     *          the query to transform.
-     * @param ebXML
-     *          the EbXML representation.
-     */
-    @Override
-    public void toEbXML(FindMedicationAdministrationsQuery query, EbXMLAdhocQueryRequest ebXML) {
-        if (query == null || ebXML == null) {
-            return;
-        }
-
-        super.toEbXML(query, ebXML);
-
-        QuerySlotHelper slots = new QuerySlotHelper(ebXML);
-
-        slots.fromString(SUBMISSION_SET_PATIENT_ID, Hl7v2Based.render(query.getPatientId()));
-    }
-
-    /**
-     * Transforms the ebXML representation of a query into a query object.
-     * <p>
-     * Does not perform any transformation if one of the parameters is <code>null</code>.
-     * @param query
-     *          the query. Can be <code>null</code>.
-     * @param ebXML
-     *          the ebXML representation. Can be <code>null</code>.
-     */
-    @Override
-    public void fromEbXML(FindMedicationAdministrationsQuery query, EbXMLAdhocQueryRequest ebXML) {
-        if (query == null || ebXML == null) {
-            return;
-        }
-
-        super.fromEbXML(query, ebXML);
-
-        QuerySlotHelper slots = new QuerySlotHelper(ebXML);
-
-        String patientId = slots.toString(SUBMISSION_SET_PATIENT_ID);
-        query.setPatientId(Hl7v2Based.parse(patientId, Identifiable.class));
-    }
+public class FindMedicationAdministrationsQueryTransformer extends Pharm1StableDocumentsQueryTransformer<FindMedicationAdministrationsQuery> {
 }

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/FindMedicationListQueryTransformer.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/FindMedicationListQueryTransformer.java
@@ -46,10 +46,9 @@ public class FindMedicationListQueryTransformer extends AbstractStoredQueryTrans
 
         super.toEbXML(query, ebXML);
 
-        // TODO:QLIG
         QuerySlotHelper slots = new QuerySlotHelper(ebXML);
 
-        slots.fromString(SUBMISSION_SET_PATIENT_ID, Hl7v2Based.render(query.getPatientId()));
+        slots.fromString(DOC_ENTRY_PATIENT_ID, Hl7v2Based.render(query.getPatientId()));
 
         slots.fromNumber(DOC_ENTRY_SERVICE_START_TIME_FROM, toHL7(query.getServiceStartTime().getFrom()));
         slots.fromNumber(DOC_ENTRY_SERVICE_START_TIME_TO, toHL7(query.getServiceStartTime().getTo()));
@@ -80,10 +79,9 @@ public class FindMedicationListQueryTransformer extends AbstractStoredQueryTrans
 
         super.fromEbXML(query, ebXML);
 
-        // TODO:QLIG
         QuerySlotHelper slots = new QuerySlotHelper(ebXML);
 
-        String patientId = slots.toString(SUBMISSION_SET_PATIENT_ID);
+        String patientId = slots.toString(DOC_ENTRY_PATIENT_ID);
         query.setPatientId(Hl7v2Based.parse(patientId, Identifiable.class));
 
         query.getServiceStartTime().setFrom(slots.toNumber(DOC_ENTRY_SERVICE_START_TIME_FROM));

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/FindMedicationListQueryTransformer.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/FindMedicationListQueryTransformer.java
@@ -15,6 +15,7 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.transform.requests.query;
 
+import static org.openehealth.ipf.commons.ihe.xds.core.metadata.Timestamp.toHL7;
 import static org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryParameter.*;
 
 import org.openehealth.ipf.commons.ihe.xds.core.ebxml.EbXMLAdhocQueryRequest;
@@ -45,9 +46,21 @@ public class FindMedicationListQueryTransformer extends AbstractStoredQueryTrans
 
         super.toEbXML(query, ebXML);
 
+        // TODO:QLIG
         QuerySlotHelper slots = new QuerySlotHelper(ebXML);
 
         slots.fromString(SUBMISSION_SET_PATIENT_ID, Hl7v2Based.render(query.getPatientId()));
+
+        slots.fromNumber(DOC_ENTRY_SERVICE_START_TIME_FROM, toHL7(query.getServiceStartTime().getFrom()));
+        slots.fromNumber(DOC_ENTRY_SERVICE_START_TIME_TO, toHL7(query.getServiceStartTime().getTo()));
+
+        slots.fromNumber(DOC_ENTRY_SERVICE_STOP_TIME_FROM, toHL7(query.getServiceStopTime().getFrom()));
+        slots.fromNumber(DOC_ENTRY_SERVICE_STOP_TIME_TO, toHL7(query.getServiceStopTime().getTo()));
+
+        slots.fromCode(DOC_ENTRY_FORMAT_CODE, query.getFormatCodes());
+        slots.fromCode(DOC_ENTRY_TYPE_CODE, query.getTypeCodes());
+        slots.fromStatus(DOC_ENTRY_STATUS, query.getStatus());
+        slots.fromInteger(METADATA_LEVEL, query.getMetadataLevel());
     }
 
     /**
@@ -67,9 +80,21 @@ public class FindMedicationListQueryTransformer extends AbstractStoredQueryTrans
 
         super.fromEbXML(query, ebXML);
 
+        // TODO:QLIG
         QuerySlotHelper slots = new QuerySlotHelper(ebXML);
 
         String patientId = slots.toString(SUBMISSION_SET_PATIENT_ID);
         query.setPatientId(Hl7v2Based.parse(patientId, Identifiable.class));
+
+        query.getServiceStartTime().setFrom(slots.toNumber(DOC_ENTRY_SERVICE_START_TIME_FROM));
+        query.getServiceStartTime().setTo(slots.toNumber(DOC_ENTRY_SERVICE_START_TIME_TO));
+
+        query.getServiceStopTime().setFrom(slots.toNumber(DOC_ENTRY_SERVICE_STOP_TIME_FROM));
+        query.getServiceStopTime().setTo(slots.toNumber(DOC_ENTRY_SERVICE_STOP_TIME_TO));
+
+        query.setFormatCodes(slots.toCodeList(DOC_ENTRY_FORMAT_CODE));
+        query.setTypeCodes(slots.toCodeList(DOC_ENTRY_TYPE_CODE));
+        query.setStatus(slots.toStatus(DOC_ENTRY_STATUS));
+        query.setMetadataLevel(slots.toInteger(METADATA_LEVEL));
     }
 }

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/FindMedicationListQueryTransformer.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/FindMedicationListQueryTransformer.java
@@ -19,15 +19,13 @@ import static org.openehealth.ipf.commons.ihe.xds.core.metadata.Timestamp.toHL7;
 import static org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryParameter.*;
 
 import org.openehealth.ipf.commons.ihe.xds.core.ebxml.EbXMLAdhocQueryRequest;
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.Hl7v2Based;
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
 import org.openehealth.ipf.commons.ihe.xds.core.requests.query.FindMedicationListQuery;
 
 /**
  * Transforms between {@link FindMedicationListQuery} and {@link EbXMLAdhocQueryRequest}.
  * @author Quentin Ligier
  */
-public class FindMedicationListQueryTransformer extends AbstractStoredQueryTransformer<FindMedicationListQuery> {
+public class FindMedicationListQueryTransformer extends PharmacyDocumentsQueryTransformer<FindMedicationListQuery> {
 
     /**
      * Transforms the query into its EbXML representation.
@@ -45,21 +43,16 @@ public class FindMedicationListQueryTransformer extends AbstractStoredQueryTrans
         }
 
         super.toEbXML(query, ebXML);
-
         QuerySlotHelper slots = new QuerySlotHelper(ebXML);
-
-        slots.fromString(DOC_ENTRY_PATIENT_ID, Hl7v2Based.render(query.getPatientId()));
-
-        slots.fromNumber(DOC_ENTRY_SERVICE_START_TIME_FROM, toHL7(query.getServiceStartTime().getFrom()));
-        slots.fromNumber(DOC_ENTRY_SERVICE_START_TIME_TO, toHL7(query.getServiceStartTime().getTo()));
-
-        slots.fromNumber(DOC_ENTRY_SERVICE_STOP_TIME_FROM, toHL7(query.getServiceStopTime().getFrom()));
-        slots.fromNumber(DOC_ENTRY_SERVICE_STOP_TIME_TO, toHL7(query.getServiceStopTime().getTo()));
 
         slots.fromCode(DOC_ENTRY_FORMAT_CODE, query.getFormatCodes());
         slots.fromCode(DOC_ENTRY_TYPE_CODE, query.getTypeCodes());
-        slots.fromStatus(DOC_ENTRY_STATUS, query.getStatus());
-        slots.fromInteger(METADATA_LEVEL, query.getMetadataLevel());
+
+        slots.fromNumber(DOC_ENTRY_SERVICE_START_FROM, toHL7(query.getServiceStart().getFrom()));
+        slots.fromNumber(DOC_ENTRY_SERVICE_START_TO, toHL7(query.getServiceStart().getTo()));
+
+        slots.fromNumber(DOC_ENTRY_SERVICE_END_FROM, toHL7(query.getServiceEnd().getFrom()));
+        slots.fromNumber(DOC_ENTRY_SERVICE_END_TO, toHL7(query.getServiceEnd().getTo()));
     }
 
     /**
@@ -78,21 +71,15 @@ public class FindMedicationListQueryTransformer extends AbstractStoredQueryTrans
         }
 
         super.fromEbXML(query, ebXML);
-
         QuerySlotHelper slots = new QuerySlotHelper(ebXML);
-
-        String patientId = slots.toString(DOC_ENTRY_PATIENT_ID);
-        query.setPatientId(Hl7v2Based.parse(patientId, Identifiable.class));
-
-        query.getServiceStartTime().setFrom(slots.toNumber(DOC_ENTRY_SERVICE_START_TIME_FROM));
-        query.getServiceStartTime().setTo(slots.toNumber(DOC_ENTRY_SERVICE_START_TIME_TO));
-
-        query.getServiceStopTime().setFrom(slots.toNumber(DOC_ENTRY_SERVICE_STOP_TIME_FROM));
-        query.getServiceStopTime().setTo(slots.toNumber(DOC_ENTRY_SERVICE_STOP_TIME_TO));
 
         query.setFormatCodes(slots.toCodeList(DOC_ENTRY_FORMAT_CODE));
         query.setTypeCodes(slots.toCodeList(DOC_ENTRY_TYPE_CODE));
-        query.setStatus(slots.toStatus(DOC_ENTRY_STATUS));
-        query.setMetadataLevel(slots.toInteger(METADATA_LEVEL));
+
+        query.getServiceStart().setFrom(slots.toNumber(DOC_ENTRY_SERVICE_START_FROM));
+        query.getServiceStart().setTo(slots.toNumber(DOC_ENTRY_SERVICE_START_TO));
+
+        query.getServiceEnd().setFrom(slots.toNumber(DOC_ENTRY_SERVICE_END_FROM));
+        query.getServiceEnd().setTo(slots.toNumber(DOC_ENTRY_SERVICE_END_TO));
     }
 }

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/FindMedicationListQueryTransformer.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/FindMedicationListQueryTransformer.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openehealth.ipf.commons.ihe.xds.core.transform.requests.query;
+
+import static org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryParameter.*;
+
+import org.openehealth.ipf.commons.ihe.xds.core.ebxml.EbXMLAdhocQueryRequest;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Hl7v2Based;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.query.FindMedicationListQuery;
+
+/**
+ * Transforms between {@link FindMedicationListQuery} and {@link EbXMLAdhocQueryRequest}.
+ * @author Quentin Ligier
+ */
+public class FindMedicationListQueryTransformer extends AbstractStoredQueryTransformer<FindMedicationListQuery> {
+
+    /**
+     * Transforms the query into its EbXML representation.
+     * <p>
+     * Does not perform any transformation if one of the parameters is <code>null</code>.
+     * @param query
+     *          the query to transform.
+     * @param ebXML
+     *          the EbXML representation.
+     */
+    @Override
+    public void toEbXML(FindMedicationListQuery query, EbXMLAdhocQueryRequest ebXML) {
+        if (query == null || ebXML == null) {
+            return;
+        }
+
+        super.toEbXML(query, ebXML);
+
+        QuerySlotHelper slots = new QuerySlotHelper(ebXML);
+
+        slots.fromString(SUBMISSION_SET_PATIENT_ID, Hl7v2Based.render(query.getPatientId()));
+    }
+
+    /**
+     * Transforms the ebXML representation of a query into a query object.
+     * <p>
+     * Does not perform any transformation if one of the parameters is <code>null</code>.
+     * @param query
+     *          the query. Can be <code>null</code>.
+     * @param ebXML
+     *          the ebXML representation. Can be <code>null</code>.
+     */
+    @Override
+    public void fromEbXML(FindMedicationListQuery query, EbXMLAdhocQueryRequest ebXML) {
+        if (query == null || ebXML == null) {
+            return;
+        }
+
+        super.fromEbXML(query, ebXML);
+
+        QuerySlotHelper slots = new QuerySlotHelper(ebXML);
+
+        String patientId = slots.toString(SUBMISSION_SET_PATIENT_ID);
+        query.setPatientId(Hl7v2Based.parse(patientId, Identifiable.class));
+    }
+}

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/FindMedicationTreatmentPlansQueryTransformer.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/FindMedicationTreatmentPlansQueryTransformer.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openehealth.ipf.commons.ihe.xds.core.transform.requests.query;
+
+import static org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryParameter.*;
+
+import org.openehealth.ipf.commons.ihe.xds.core.ebxml.EbXMLAdhocQueryRequest;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Hl7v2Based;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.query.FindMedicationTreatmentPlansQuery;
+
+/**
+ * Transforms between {@link FindMedicationTreatmentPlansQuery} and {@link EbXMLAdhocQueryRequest}.
+ * @author Quentin Ligier
+ */
+public class FindMedicationTreatmentPlansQueryTransformer extends AbstractStoredQueryTransformer<FindMedicationTreatmentPlansQuery> {
+
+    /**
+     * Transforms the query into its EbXML representation.
+     * <p>
+     * Does not perform any transformation if one of the parameters is <code>null</code>.
+     * @param query
+     *          the query to transform.
+     * @param ebXML
+     *          the EbXML representation.
+     */
+    @Override
+    public void toEbXML(FindMedicationTreatmentPlansQuery query, EbXMLAdhocQueryRequest ebXML) {
+        if (query == null || ebXML == null) {
+            return;
+        }
+
+        super.toEbXML(query, ebXML);
+
+        QuerySlotHelper slots = new QuerySlotHelper(ebXML);
+
+        slots.fromString(SUBMISSION_SET_PATIENT_ID, Hl7v2Based.render(query.getPatientId()));
+    }
+
+    /**
+     * Transforms the ebXML representation of a query into a query object.
+     * <p>
+     * Does not perform any transformation if one of the parameters is <code>null</code>.
+     * @param query
+     *          the query. Can be <code>null</code>.
+     * @param ebXML
+     *          the ebXML representation. Can be <code>null</code>.
+     */
+    @Override
+    public void fromEbXML(FindMedicationTreatmentPlansQuery query, EbXMLAdhocQueryRequest ebXML) {
+        if (query == null || ebXML == null) {
+            return;
+        }
+
+        super.fromEbXML(query, ebXML);
+
+        QuerySlotHelper slots = new QuerySlotHelper(ebXML);
+
+        String patientId = slots.toString(SUBMISSION_SET_PATIENT_ID);
+        query.setPatientId(Hl7v2Based.parse(patientId, Identifiable.class));
+    }
+}

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/FindMedicationTreatmentPlansQueryTransformer.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/FindMedicationTreatmentPlansQueryTransformer.java
@@ -15,61 +15,12 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.transform.requests.query;
 
-import static org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryParameter.*;
-
 import org.openehealth.ipf.commons.ihe.xds.core.ebxml.EbXMLAdhocQueryRequest;
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.Hl7v2Based;
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
 import org.openehealth.ipf.commons.ihe.xds.core.requests.query.FindMedicationTreatmentPlansQuery;
 
 /**
  * Transforms between {@link FindMedicationTreatmentPlansQuery} and {@link EbXMLAdhocQueryRequest}.
  * @author Quentin Ligier
  */
-public class FindMedicationTreatmentPlansQueryTransformer extends AbstractStoredQueryTransformer<FindMedicationTreatmentPlansQuery> {
-
-    /**
-     * Transforms the query into its EbXML representation.
-     * <p>
-     * Does not perform any transformation if one of the parameters is <code>null</code>.
-     * @param query
-     *          the query to transform.
-     * @param ebXML
-     *          the EbXML representation.
-     */
-    @Override
-    public void toEbXML(FindMedicationTreatmentPlansQuery query, EbXMLAdhocQueryRequest ebXML) {
-        if (query == null || ebXML == null) {
-            return;
-        }
-
-        super.toEbXML(query, ebXML);
-
-        QuerySlotHelper slots = new QuerySlotHelper(ebXML);
-
-        slots.fromString(SUBMISSION_SET_PATIENT_ID, Hl7v2Based.render(query.getPatientId()));
-    }
-
-    /**
-     * Transforms the ebXML representation of a query into a query object.
-     * <p>
-     * Does not perform any transformation if one of the parameters is <code>null</code>.
-     * @param query
-     *          the query. Can be <code>null</code>.
-     * @param ebXML
-     *          the ebXML representation. Can be <code>null</code>.
-     */
-    @Override
-    public void fromEbXML(FindMedicationTreatmentPlansQuery query, EbXMLAdhocQueryRequest ebXML) {
-        if (query == null || ebXML == null) {
-            return;
-        }
-
-        super.fromEbXML(query, ebXML);
-
-        QuerySlotHelper slots = new QuerySlotHelper(ebXML);
-
-        String patientId = slots.toString(SUBMISSION_SET_PATIENT_ID);
-        query.setPatientId(Hl7v2Based.parse(patientId, Identifiable.class));
-    }
+public class FindMedicationTreatmentPlansQueryTransformer extends Pharm1StableDocumentsQueryTransformer<FindMedicationTreatmentPlansQuery> {
 }

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/FindPrescriptionsForDispenseQueryTransformer.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/FindPrescriptionsForDispenseQueryTransformer.java
@@ -15,61 +15,12 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.transform.requests.query;
 
-import static org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryParameter.*;
-
 import org.openehealth.ipf.commons.ihe.xds.core.ebxml.EbXMLAdhocQueryRequest;
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.Hl7v2Based;
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
 import org.openehealth.ipf.commons.ihe.xds.core.requests.query.FindPrescriptionsForDispenseQuery;
 
 /**
  * Transforms between {@link FindPrescriptionsForDispenseQuery} and {@link EbXMLAdhocQueryRequest}.
  * @author Quentin Ligier
  */
-public class FindPrescriptionsForDispenseQueryTransformer extends AbstractStoredQueryTransformer<FindPrescriptionsForDispenseQuery> {
-
-    /**
-     * Transforms the query into its EbXML representation.
-     * <p>
-     * Does not perform any transformation if one of the parameters is <code>null</code>.
-     * @param query
-     *          the query to transform.
-     * @param ebXML
-     *          the EbXML representation.
-     */
-    @Override
-    public void toEbXML(FindPrescriptionsForDispenseQuery query, EbXMLAdhocQueryRequest ebXML) {
-        if (query == null || ebXML == null) {
-            return;
-        }
-
-        super.toEbXML(query, ebXML);
-
-        QuerySlotHelper slots = new QuerySlotHelper(ebXML);
-
-        slots.fromString(SUBMISSION_SET_PATIENT_ID, Hl7v2Based.render(query.getPatientId()));
-    }
-
-    /**
-     * Transforms the ebXML representation of a query into a query object.
-     * <p>
-     * Does not perform any transformation if one of the parameters is <code>null</code>.
-     * @param query
-     *          the query. Can be <code>null</code>.
-     * @param ebXML
-     *          the ebXML representation. Can be <code>null</code>.
-     */
-    @Override
-    public void fromEbXML(FindPrescriptionsForDispenseQuery query, EbXMLAdhocQueryRequest ebXML) {
-        if (query == null || ebXML == null) {
-            return;
-        }
-
-        super.fromEbXML(query, ebXML);
-
-        QuerySlotHelper slots = new QuerySlotHelper(ebXML);
-
-        String patientId = slots.toString(SUBMISSION_SET_PATIENT_ID);
-        query.setPatientId(Hl7v2Based.parse(patientId, Identifiable.class));
-    }
+public class FindPrescriptionsForDispenseQueryTransformer extends Pharm1StableDocumentsQueryTransformer<FindPrescriptionsForDispenseQuery> {
 }

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/FindPrescriptionsForDispenseQueryTransformer.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/FindPrescriptionsForDispenseQueryTransformer.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openehealth.ipf.commons.ihe.xds.core.transform.requests.query;
+
+import static org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryParameter.*;
+
+import org.openehealth.ipf.commons.ihe.xds.core.ebxml.EbXMLAdhocQueryRequest;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Hl7v2Based;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.query.FindPrescriptionsForDispenseQuery;
+
+/**
+ * Transforms between {@link FindPrescriptionsForDispenseQuery} and {@link EbXMLAdhocQueryRequest}.
+ * @author Quentin Ligier
+ */
+public class FindPrescriptionsForDispenseQueryTransformer extends AbstractStoredQueryTransformer<FindPrescriptionsForDispenseQuery> {
+
+    /**
+     * Transforms the query into its EbXML representation.
+     * <p>
+     * Does not perform any transformation if one of the parameters is <code>null</code>.
+     * @param query
+     *          the query to transform.
+     * @param ebXML
+     *          the EbXML representation.
+     */
+    @Override
+    public void toEbXML(FindPrescriptionsForDispenseQuery query, EbXMLAdhocQueryRequest ebXML) {
+        if (query == null || ebXML == null) {
+            return;
+        }
+
+        super.toEbXML(query, ebXML);
+
+        QuerySlotHelper slots = new QuerySlotHelper(ebXML);
+
+        slots.fromString(SUBMISSION_SET_PATIENT_ID, Hl7v2Based.render(query.getPatientId()));
+    }
+
+    /**
+     * Transforms the ebXML representation of a query into a query object.
+     * <p>
+     * Does not perform any transformation if one of the parameters is <code>null</code>.
+     * @param query
+     *          the query. Can be <code>null</code>.
+     * @param ebXML
+     *          the ebXML representation. Can be <code>null</code>.
+     */
+    @Override
+    public void fromEbXML(FindPrescriptionsForDispenseQuery query, EbXMLAdhocQueryRequest ebXML) {
+        if (query == null || ebXML == null) {
+            return;
+        }
+
+        super.fromEbXML(query, ebXML);
+
+        QuerySlotHelper slots = new QuerySlotHelper(ebXML);
+
+        String patientId = slots.toString(SUBMISSION_SET_PATIENT_ID);
+        query.setPatientId(Hl7v2Based.parse(patientId, Identifiable.class));
+    }
+}

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/FindPrescriptionsForValidationQueryTransformer.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/FindPrescriptionsForValidationQueryTransformer.java
@@ -15,61 +15,12 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.transform.requests.query;
 
-import static org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryParameter.*;
-
 import org.openehealth.ipf.commons.ihe.xds.core.ebxml.EbXMLAdhocQueryRequest;
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.Hl7v2Based;
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
 import org.openehealth.ipf.commons.ihe.xds.core.requests.query.FindPrescriptionsForValidationQuery;
 
 /**
  * Transforms between {@link FindPrescriptionsForValidationQuery} and {@link EbXMLAdhocQueryRequest}.
  * @author Quentin Ligier
  */
-public class FindPrescriptionsForValidationQueryTransformer extends AbstractStoredQueryTransformer<FindPrescriptionsForValidationQuery> {
-
-    /**
-     * Transforms the query into its EbXML representation.
-     * <p>
-     * Does not perform any transformation if one of the parameters is <code>null</code>.
-     * @param query
-     *          the query to transform.
-     * @param ebXML
-     *          the EbXML representation.
-     */
-    @Override
-    public void toEbXML(FindPrescriptionsForValidationQuery query, EbXMLAdhocQueryRequest ebXML) {
-        if (query == null || ebXML == null) {
-            return;
-        }
-
-        super.toEbXML(query, ebXML);
-
-        QuerySlotHelper slots = new QuerySlotHelper(ebXML);
-
-        slots.fromString(SUBMISSION_SET_PATIENT_ID, Hl7v2Based.render(query.getPatientId()));
-    }
-
-    /**
-     * Transforms the ebXML representation of a query into a query object.
-     * <p>
-     * Does not perform any transformation if one of the parameters is <code>null</code>.
-     * @param query
-     *          the query. Can be <code>null</code>.
-     * @param ebXML
-     *          the ebXML representation. Can be <code>null</code>.
-     */
-    @Override
-    public void fromEbXML(FindPrescriptionsForValidationQuery query, EbXMLAdhocQueryRequest ebXML) {
-        if (query == null || ebXML == null) {
-            return;
-        }
-
-        super.fromEbXML(query, ebXML);
-
-        QuerySlotHelper slots = new QuerySlotHelper(ebXML);
-
-        String patientId = slots.toString(SUBMISSION_SET_PATIENT_ID);
-        query.setPatientId(Hl7v2Based.parse(patientId, Identifiable.class));
-    }
+public class FindPrescriptionsForValidationQueryTransformer extends Pharm1StableDocumentsQueryTransformer<FindPrescriptionsForValidationQuery> {
 }

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/FindPrescriptionsForValidationQueryTransformer.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/FindPrescriptionsForValidationQueryTransformer.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openehealth.ipf.commons.ihe.xds.core.transform.requests.query;
+
+import static org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryParameter.*;
+
+import org.openehealth.ipf.commons.ihe.xds.core.ebxml.EbXMLAdhocQueryRequest;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Hl7v2Based;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.query.FindPrescriptionsForValidationQuery;
+
+/**
+ * Transforms between {@link FindPrescriptionsForValidationQuery} and {@link EbXMLAdhocQueryRequest}.
+ * @author Quentin Ligier
+ */
+public class FindPrescriptionsForValidationQueryTransformer extends AbstractStoredQueryTransformer<FindPrescriptionsForValidationQuery> {
+
+    /**
+     * Transforms the query into its EbXML representation.
+     * <p>
+     * Does not perform any transformation if one of the parameters is <code>null</code>.
+     * @param query
+     *          the query to transform.
+     * @param ebXML
+     *          the EbXML representation.
+     */
+    @Override
+    public void toEbXML(FindPrescriptionsForValidationQuery query, EbXMLAdhocQueryRequest ebXML) {
+        if (query == null || ebXML == null) {
+            return;
+        }
+
+        super.toEbXML(query, ebXML);
+
+        QuerySlotHelper slots = new QuerySlotHelper(ebXML);
+
+        slots.fromString(SUBMISSION_SET_PATIENT_ID, Hl7v2Based.render(query.getPatientId()));
+    }
+
+    /**
+     * Transforms the ebXML representation of a query into a query object.
+     * <p>
+     * Does not perform any transformation if one of the parameters is <code>null</code>.
+     * @param query
+     *          the query. Can be <code>null</code>.
+     * @param ebXML
+     *          the ebXML representation. Can be <code>null</code>.
+     */
+    @Override
+    public void fromEbXML(FindPrescriptionsForValidationQuery query, EbXMLAdhocQueryRequest ebXML) {
+        if (query == null || ebXML == null) {
+            return;
+        }
+
+        super.fromEbXML(query, ebXML);
+
+        QuerySlotHelper slots = new QuerySlotHelper(ebXML);
+
+        String patientId = slots.toString(SUBMISSION_SET_PATIENT_ID);
+        query.setPatientId(Hl7v2Based.parse(patientId, Identifiable.class));
+    }
+}

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/FindPrescriptionsQueryTransformer.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/FindPrescriptionsQueryTransformer.java
@@ -15,61 +15,12 @@
  */
 package org.openehealth.ipf.commons.ihe.xds.core.transform.requests.query;
 
-import static org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryParameter.*;
-
 import org.openehealth.ipf.commons.ihe.xds.core.ebxml.EbXMLAdhocQueryRequest;
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.Hl7v2Based;
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
 import org.openehealth.ipf.commons.ihe.xds.core.requests.query.FindPrescriptionsQuery;
 
 /**
  * Transforms between {@link FindPrescriptionsQuery} and {@link EbXMLAdhocQueryRequest}.
  * @author Quentin Ligier
  */
-public class FindPrescriptionsQueryTransformer extends AbstractStoredQueryTransformer<FindPrescriptionsQuery> {
-
-    /**
-     * Transforms the query into its EbXML representation.
-     * <p>
-     * Does not perform any transformation if one of the parameters is <code>null</code>.
-     * @param query
-     *          the query to transform.
-     * @param ebXML
-     *          the EbXML representation.
-     */
-    @Override
-    public void toEbXML(FindPrescriptionsQuery query, EbXMLAdhocQueryRequest ebXML) {
-        if (query == null || ebXML == null) {
-            return;
-        }
-
-        super.toEbXML(query, ebXML);
-
-        QuerySlotHelper slots = new QuerySlotHelper(ebXML);
-
-        slots.fromString(SUBMISSION_SET_PATIENT_ID, Hl7v2Based.render(query.getPatientId()));
-    }
-
-    /**
-     * Transforms the ebXML representation of a query into a query object.
-     * <p>
-     * Does not perform any transformation if one of the parameters is <code>null</code>.
-     * @param query
-     *          the query. Can be <code>null</code>.
-     * @param ebXML
-     *          the ebXML representation. Can be <code>null</code>.
-     */
-    @Override
-    public void fromEbXML(FindPrescriptionsQuery query, EbXMLAdhocQueryRequest ebXML) {
-        if (query == null || ebXML == null) {
-            return;
-        }
-
-        super.fromEbXML(query, ebXML);
-
-        QuerySlotHelper slots = new QuerySlotHelper(ebXML);
-
-        String patientId = slots.toString(SUBMISSION_SET_PATIENT_ID);
-        query.setPatientId(Hl7v2Based.parse(patientId, Identifiable.class));
-    }
+public class FindPrescriptionsQueryTransformer extends Pharm1StableDocumentsQueryTransformer<FindPrescriptionsQuery> {
 }

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/FindPrescriptionsQueryTransformer.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/FindPrescriptionsQueryTransformer.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openehealth.ipf.commons.ihe.xds.core.transform.requests.query;
+
+import static org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryParameter.*;
+
+import org.openehealth.ipf.commons.ihe.xds.core.ebxml.EbXMLAdhocQueryRequest;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Hl7v2Based;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.query.FindPrescriptionsQuery;
+
+/**
+ * Transforms between {@link FindPrescriptionsQuery} and {@link EbXMLAdhocQueryRequest}.
+ * @author Quentin Ligier
+ */
+public class FindPrescriptionsQueryTransformer extends AbstractStoredQueryTransformer<FindPrescriptionsQuery> {
+
+    /**
+     * Transforms the query into its EbXML representation.
+     * <p>
+     * Does not perform any transformation if one of the parameters is <code>null</code>.
+     * @param query
+     *          the query to transform.
+     * @param ebXML
+     *          the EbXML representation.
+     */
+    @Override
+    public void toEbXML(FindPrescriptionsQuery query, EbXMLAdhocQueryRequest ebXML) {
+        if (query == null || ebXML == null) {
+            return;
+        }
+
+        super.toEbXML(query, ebXML);
+
+        QuerySlotHelper slots = new QuerySlotHelper(ebXML);
+
+        slots.fromString(SUBMISSION_SET_PATIENT_ID, Hl7v2Based.render(query.getPatientId()));
+    }
+
+    /**
+     * Transforms the ebXML representation of a query into a query object.
+     * <p>
+     * Does not perform any transformation if one of the parameters is <code>null</code>.
+     * @param query
+     *          the query. Can be <code>null</code>.
+     * @param ebXML
+     *          the ebXML representation. Can be <code>null</code>.
+     */
+    @Override
+    public void fromEbXML(FindPrescriptionsQuery query, EbXMLAdhocQueryRequest ebXML) {
+        if (query == null || ebXML == null) {
+            return;
+        }
+
+        super.fromEbXML(query, ebXML);
+
+        QuerySlotHelper slots = new QuerySlotHelper(ebXML);
+
+        String patientId = slots.toString(SUBMISSION_SET_PATIENT_ID);
+        query.setPatientId(Hl7v2Based.parse(patientId, Identifiable.class));
+    }
+}

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/Pharm1StableDocumentsQueryTransformer.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/Pharm1StableDocumentsQueryTransformer.java
@@ -1,0 +1,87 @@
+package org.openehealth.ipf.commons.ihe.xds.core.transform.requests.query;
+
+import org.openehealth.ipf.commons.ihe.xds.core.ebxml.EbXMLAdhocQueryRequest;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Hl7v2Based;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.query.Pharm1StableDocumentsQuery;
+
+import static org.openehealth.ipf.commons.ihe.xds.core.metadata.Timestamp.toHL7;
+import static org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryParameter.*;
+
+abstract class Pharm1StableDocumentsQueryTransformer<T extends Pharm1StableDocumentsQuery> extends AbstractStoredQueryTransformer<T> {
+
+    /**
+     * Transforms the query into its ebXML representation.
+     * <p>
+     * Does not perform any transformation if one of the parameters is <code>null</code>.
+     * @param query
+     *          the query. Can be <code>null</code>.
+     * @param ebXML
+     *          the ebXML representation. Can be <code>null</code>.
+     */
+    public void toEbXML(T query, EbXMLAdhocQueryRequest ebXML) {
+        if (query == null || ebXML == null) {
+            return;
+        }
+
+        super.toEbXML(query, ebXML);
+
+        QuerySlotHelper slots = new QuerySlotHelper(ebXML);
+
+        slots.fromString(SUBMISSION_SET_PATIENT_ID, Hl7v2Based.render(query.getPatientId()));
+        slots.fromStringList(DOC_ENTRY_AUTHOR_PERSON, query.getAuthorPersons());
+
+        slots.fromNumber(DOC_ENTRY_CREATION_TIME_FROM, toHL7(query.getCreationTime().getFrom()));
+        slots.fromNumber(DOC_ENTRY_CREATION_TIME_TO, toHL7(query.getCreationTime().getTo()));
+
+        slots.fromNumber(DOC_ENTRY_SERVICE_START_TIME_FROM, toHL7(query.getServiceStartTime().getFrom()));
+        slots.fromNumber(DOC_ENTRY_SERVICE_START_TIME_TO, toHL7(query.getServiceStartTime().getTo()));
+
+        slots.fromNumber(DOC_ENTRY_SERVICE_STOP_TIME_FROM, toHL7(query.getServiceStopTime().getFrom()));
+        slots.fromNumber(DOC_ENTRY_SERVICE_STOP_TIME_TO, toHL7(query.getServiceStopTime().getTo()));
+
+        slots.fromCode(DOC_ENTRY_HEALTHCARE_FACILITY_TYPE_CODE, query.getHealthcareFacilityTypeCodes());
+        slots.fromCode(DOC_ENTRY_PRACTICE_SETTING_CODE, query.getPracticeSettingCodes());
+        slots.fromCode(DOC_ENTRY_EVENT_CODE, query.getEventCodes());
+        slots.fromCode(DOC_ENTRY_CONFIDENTIALITY_CODE, query.getConfidentialityCodes());
+    }
+
+    /**
+     * Transforms the ebXML representation of a query into a query object.
+     * <p>
+     * Does not perform any transformation if one of the parameters is <code>null</code>.
+     * @param query
+     *          the query. Can be <code>null</code>.
+     * @param ebXML
+     *          the ebXML representation. Can be <code>null</code>.
+     */
+    public void fromEbXML(T query, EbXMLAdhocQueryRequest ebXML) {
+        if (query == null || ebXML == null) {
+            return;
+        }
+
+        super.fromEbXML(query, ebXML);
+
+        QuerySlotHelper slots = new QuerySlotHelper(ebXML);
+
+        query.setPracticeSettingCodes(slots.toCodeList(DOC_ENTRY_PRACTICE_SETTING_CODE));
+        query.setHealthcareFacilityTypeCodes(slots.toCodeList(DOC_ENTRY_HEALTHCARE_FACILITY_TYPE_CODE));
+
+        query.setEventCodes(slots.toCodeQueryList(DOC_ENTRY_EVENT_CODE, DOC_ENTRY_EVENT_CODE_SCHEME));
+        query.setConfidentialityCodes(slots.toCodeQueryList(DOC_ENTRY_CONFIDENTIALITY_CODE, DOC_ENTRY_CONFIDENTIALITY_CODE_SCHEME));
+
+
+        String patientId = slots.toString(SUBMISSION_SET_PATIENT_ID);
+        query.setPatientId(Hl7v2Based.parse(patientId, Identifiable.class));
+        query.setAuthorPersons(slots.toStringList(DOC_ENTRY_AUTHOR_PERSON));
+
+        query.getCreationTime().setFrom(slots.toNumber(DOC_ENTRY_CREATION_TIME_FROM));
+        query.getCreationTime().setTo(slots.toNumber(DOC_ENTRY_CREATION_TIME_TO));
+
+        query.getServiceStartTime().setFrom(slots.toNumber(DOC_ENTRY_SERVICE_START_TIME_FROM));
+        query.getServiceStartTime().setTo(slots.toNumber(DOC_ENTRY_SERVICE_START_TIME_TO));
+
+        query.getServiceStopTime().setFrom(slots.toNumber(DOC_ENTRY_SERVICE_STOP_TIME_FROM));
+        query.getServiceStopTime().setTo(slots.toNumber(DOC_ENTRY_SERVICE_STOP_TIME_TO));
+    }
+}

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/Pharm1StableDocumentsQueryTransformer.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/Pharm1StableDocumentsQueryTransformer.java
@@ -8,6 +8,10 @@ import org.openehealth.ipf.commons.ihe.xds.core.requests.query.Pharm1StableDocum
 import static org.openehealth.ipf.commons.ihe.xds.core.metadata.Timestamp.toHL7;
 import static org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryParameter.*;
 
+/**
+ * Base transformations for all stable-documents PHARM-1 queries.
+ * @author Quentin Ligier
+ */
 abstract class Pharm1StableDocumentsQueryTransformer<T extends Pharm1StableDocumentsQuery> extends AbstractStoredQueryTransformer<T> {
 
     /**
@@ -23,12 +27,12 @@ abstract class Pharm1StableDocumentsQueryTransformer<T extends Pharm1StableDocum
         if (query == null || ebXML == null) {
             return;
         }
-// TODO:QLIG Check all param names
+
         super.toEbXML(query, ebXML);
 
         QuerySlotHelper slots = new QuerySlotHelper(ebXML);
 
-        slots.fromString(SUBMISSION_SET_PATIENT_ID, Hl7v2Based.render(query.getPatientId()));
+        slots.fromString(DOC_ENTRY_PATIENT_ID, Hl7v2Based.render(query.getPatientId()));
         slots.fromStringList(DOC_ENTRY_AUTHOR_PERSON, query.getAuthorPersons());
 
         slots.fromStringList(DOC_ENTRY_UUID, query.getUuids());
@@ -65,7 +69,7 @@ abstract class Pharm1StableDocumentsQueryTransformer<T extends Pharm1StableDocum
         if (query == null || ebXML == null) {
             return;
         }
-// TODO:QLIG
+
         super.fromEbXML(query, ebXML);
 
         QuerySlotHelper slots = new QuerySlotHelper(ebXML);
@@ -76,7 +80,7 @@ abstract class Pharm1StableDocumentsQueryTransformer<T extends Pharm1StableDocum
         query.setConfidentialityCodes(slots.toCodeQueryList(DOC_ENTRY_CONFIDENTIALITY_CODE, DOC_ENTRY_CONFIDENTIALITY_CODE_SCHEME));
         query.setStatus(slots.toStatus(DOC_ENTRY_STATUS));
 
-        String patientId = slots.toString(SUBMISSION_SET_PATIENT_ID);
+        String patientId = slots.toString(DOC_ENTRY_PATIENT_ID);
         query.setPatientId(Hl7v2Based.parse(patientId, Identifiable.class));
         query.setAuthorPersons(slots.toStringList(DOC_ENTRY_AUTHOR_PERSON));
 

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/Pharm1StableDocumentsQueryTransformer.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/Pharm1StableDocumentsQueryTransformer.java
@@ -23,13 +23,16 @@ abstract class Pharm1StableDocumentsQueryTransformer<T extends Pharm1StableDocum
         if (query == null || ebXML == null) {
             return;
         }
-
+// TODO:QLIG Check all param names
         super.toEbXML(query, ebXML);
 
         QuerySlotHelper slots = new QuerySlotHelper(ebXML);
 
         slots.fromString(SUBMISSION_SET_PATIENT_ID, Hl7v2Based.render(query.getPatientId()));
         slots.fromStringList(DOC_ENTRY_AUTHOR_PERSON, query.getAuthorPersons());
+
+        slots.fromStringList(DOC_ENTRY_UUID, query.getUuids());
+        slots.fromStringList(DOC_ENTRY_UNIQUE_ID, query.getUniqueIds());
 
         slots.fromNumber(DOC_ENTRY_CREATION_TIME_FROM, toHL7(query.getCreationTime().getFrom()));
         slots.fromNumber(DOC_ENTRY_CREATION_TIME_TO, toHL7(query.getCreationTime().getTo()));
@@ -44,6 +47,9 @@ abstract class Pharm1StableDocumentsQueryTransformer<T extends Pharm1StableDocum
         slots.fromCode(DOC_ENTRY_PRACTICE_SETTING_CODE, query.getPracticeSettingCodes());
         slots.fromCode(DOC_ENTRY_EVENT_CODE, query.getEventCodes());
         slots.fromCode(DOC_ENTRY_CONFIDENTIALITY_CODE, query.getConfidentialityCodes());
+        slots.fromStatus(DOC_ENTRY_STATUS, query.getStatus());
+
+        slots.fromInteger(METADATA_LEVEL, query.getMetadataLevel());
     }
 
     /**
@@ -59,21 +65,23 @@ abstract class Pharm1StableDocumentsQueryTransformer<T extends Pharm1StableDocum
         if (query == null || ebXML == null) {
             return;
         }
-
+// TODO:QLIG
         super.fromEbXML(query, ebXML);
 
         QuerySlotHelper slots = new QuerySlotHelper(ebXML);
 
         query.setPracticeSettingCodes(slots.toCodeList(DOC_ENTRY_PRACTICE_SETTING_CODE));
         query.setHealthcareFacilityTypeCodes(slots.toCodeList(DOC_ENTRY_HEALTHCARE_FACILITY_TYPE_CODE));
-
         query.setEventCodes(slots.toCodeQueryList(DOC_ENTRY_EVENT_CODE, DOC_ENTRY_EVENT_CODE_SCHEME));
         query.setConfidentialityCodes(slots.toCodeQueryList(DOC_ENTRY_CONFIDENTIALITY_CODE, DOC_ENTRY_CONFIDENTIALITY_CODE_SCHEME));
-
+        query.setStatus(slots.toStatus(DOC_ENTRY_STATUS));
 
         String patientId = slots.toString(SUBMISSION_SET_PATIENT_ID);
         query.setPatientId(Hl7v2Based.parse(patientId, Identifiable.class));
         query.setAuthorPersons(slots.toStringList(DOC_ENTRY_AUTHOR_PERSON));
+
+        query.setUniqueIds(slots.toStringList(DOC_ENTRY_UNIQUE_ID));
+        query.setUuids(slots.toStringList(DOC_ENTRY_UUID));
 
         query.getCreationTime().setFrom(slots.toNumber(DOC_ENTRY_CREATION_TIME_FROM));
         query.getCreationTime().setTo(slots.toNumber(DOC_ENTRY_CREATION_TIME_TO));
@@ -83,5 +91,7 @@ abstract class Pharm1StableDocumentsQueryTransformer<T extends Pharm1StableDocum
 
         query.getServiceStopTime().setFrom(slots.toNumber(DOC_ENTRY_SERVICE_STOP_TIME_FROM));
         query.getServiceStopTime().setTo(slots.toNumber(DOC_ENTRY_SERVICE_STOP_TIME_TO));
+
+        query.setMetadataLevel(slots.toInteger(METADATA_LEVEL));
     }
 }

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/Pharm1StableDocumentsQueryTransformer.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/Pharm1StableDocumentsQueryTransformer.java
@@ -1,8 +1,21 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openehealth.ipf.commons.ihe.xds.core.transform.requests.query;
 
 import org.openehealth.ipf.commons.ihe.xds.core.ebxml.EbXMLAdhocQueryRequest;
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.Hl7v2Based;
-import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
 import org.openehealth.ipf.commons.ihe.xds.core.requests.query.Pharm1StableDocumentsQuery;
 
 import static org.openehealth.ipf.commons.ihe.xds.core.metadata.Timestamp.toHL7;
@@ -12,7 +25,7 @@ import static org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryP
  * Base transformations for all stable-documents PHARM-1 queries.
  * @author Quentin Ligier
  */
-abstract class Pharm1StableDocumentsQueryTransformer<T extends Pharm1StableDocumentsQuery> extends AbstractStoredQueryTransformer<T> {
+abstract class Pharm1StableDocumentsQueryTransformer<T extends Pharm1StableDocumentsQuery> extends PharmacyDocumentsQueryTransformer<T> {
 
     /**
      * Transforms the query into its ebXML representation.
@@ -29,31 +42,23 @@ abstract class Pharm1StableDocumentsQueryTransformer<T extends Pharm1StableDocum
         }
 
         super.toEbXML(query, ebXML);
-
         QuerySlotHelper slots = new QuerySlotHelper(ebXML);
 
-        slots.fromString(DOC_ENTRY_PATIENT_ID, Hl7v2Based.render(query.getPatientId()));
         slots.fromStringList(DOC_ENTRY_AUTHOR_PERSON, query.getAuthorPersons());
-
         slots.fromStringList(DOC_ENTRY_UUID, query.getUuids());
         slots.fromStringList(DOC_ENTRY_UNIQUE_ID, query.getUniqueIds());
-
         slots.fromNumber(DOC_ENTRY_CREATION_TIME_FROM, toHL7(query.getCreationTime().getFrom()));
         slots.fromNumber(DOC_ENTRY_CREATION_TIME_TO, toHL7(query.getCreationTime().getTo()));
+        slots.fromCode(DOC_ENTRY_HEALTHCARE_FACILITY_TYPE_CODE, query.getHealthcareFacilityTypeCodes());
+        slots.fromCode(DOC_ENTRY_PRACTICE_SETTING_CODE, query.getPracticeSettingCodes());
+        slots.fromCode(DOC_ENTRY_EVENT_CODE, query.getEventCodes());
+        slots.fromCode(DOC_ENTRY_CONFIDENTIALITY_CODE, query.getConfidentialityCodes());
 
         slots.fromNumber(DOC_ENTRY_SERVICE_START_TIME_FROM, toHL7(query.getServiceStartTime().getFrom()));
         slots.fromNumber(DOC_ENTRY_SERVICE_START_TIME_TO, toHL7(query.getServiceStartTime().getTo()));
 
         slots.fromNumber(DOC_ENTRY_SERVICE_STOP_TIME_FROM, toHL7(query.getServiceStopTime().getFrom()));
         slots.fromNumber(DOC_ENTRY_SERVICE_STOP_TIME_TO, toHL7(query.getServiceStopTime().getTo()));
-
-        slots.fromCode(DOC_ENTRY_HEALTHCARE_FACILITY_TYPE_CODE, query.getHealthcareFacilityTypeCodes());
-        slots.fromCode(DOC_ENTRY_PRACTICE_SETTING_CODE, query.getPracticeSettingCodes());
-        slots.fromCode(DOC_ENTRY_EVENT_CODE, query.getEventCodes());
-        slots.fromCode(DOC_ENTRY_CONFIDENTIALITY_CODE, query.getConfidentialityCodes());
-        slots.fromStatus(DOC_ENTRY_STATUS, query.getStatus());
-
-        slots.fromInteger(METADATA_LEVEL, query.getMetadataLevel());
     }
 
     /**
@@ -71,31 +76,22 @@ abstract class Pharm1StableDocumentsQueryTransformer<T extends Pharm1StableDocum
         }
 
         super.fromEbXML(query, ebXML);
-
         QuerySlotHelper slots = new QuerySlotHelper(ebXML);
 
-        query.setPracticeSettingCodes(slots.toCodeList(DOC_ENTRY_PRACTICE_SETTING_CODE));
-        query.setHealthcareFacilityTypeCodes(slots.toCodeList(DOC_ENTRY_HEALTHCARE_FACILITY_TYPE_CODE));
-        query.setEventCodes(slots.toCodeQueryList(DOC_ENTRY_EVENT_CODE, DOC_ENTRY_EVENT_CODE_SCHEME));
-        query.setConfidentialityCodes(slots.toCodeQueryList(DOC_ENTRY_CONFIDENTIALITY_CODE, DOC_ENTRY_CONFIDENTIALITY_CODE_SCHEME));
-        query.setStatus(slots.toStatus(DOC_ENTRY_STATUS));
-
-        String patientId = slots.toString(DOC_ENTRY_PATIENT_ID);
-        query.setPatientId(Hl7v2Based.parse(patientId, Identifiable.class));
         query.setAuthorPersons(slots.toStringList(DOC_ENTRY_AUTHOR_PERSON));
-
-        query.setUniqueIds(slots.toStringList(DOC_ENTRY_UNIQUE_ID));
-        query.setUuids(slots.toStringList(DOC_ENTRY_UUID));
-
+        query.setConfidentialityCodes(slots.toCodeQueryList(DOC_ENTRY_CONFIDENTIALITY_CODE, DOC_ENTRY_CONFIDENTIALITY_CODE_SCHEME));
         query.getCreationTime().setFrom(slots.toNumber(DOC_ENTRY_CREATION_TIME_FROM));
         query.getCreationTime().setTo(slots.toNumber(DOC_ENTRY_CREATION_TIME_TO));
+        query.setEventCodes(slots.toCodeQueryList(DOC_ENTRY_EVENT_CODE, DOC_ENTRY_EVENT_CODE_SCHEME));
+        query.setHealthcareFacilityTypeCodes(slots.toCodeList(DOC_ENTRY_HEALTHCARE_FACILITY_TYPE_CODE));
+        query.setPracticeSettingCodes(slots.toCodeList(DOC_ENTRY_PRACTICE_SETTING_CODE));
+        query.setUniqueIds(slots.toStringList(DOC_ENTRY_UNIQUE_ID));
+        query.setUuids(slots.toStringList(DOC_ENTRY_UUID));
 
         query.getServiceStartTime().setFrom(slots.toNumber(DOC_ENTRY_SERVICE_START_TIME_FROM));
         query.getServiceStartTime().setTo(slots.toNumber(DOC_ENTRY_SERVICE_START_TIME_TO));
 
         query.getServiceStopTime().setFrom(slots.toNumber(DOC_ENTRY_SERVICE_STOP_TIME_FROM));
         query.getServiceStopTime().setTo(slots.toNumber(DOC_ENTRY_SERVICE_STOP_TIME_TO));
-
-        query.setMetadataLevel(slots.toInteger(METADATA_LEVEL));
     }
 }

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/PharmacyDocumentsQueryTransformer.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/PharmacyDocumentsQueryTransformer.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openehealth.ipf.commons.ihe.xds.core.transform.requests.query;
+
+import org.openehealth.ipf.commons.ihe.xds.core.ebxml.EbXMLAdhocQueryRequest;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Hl7v2Based;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.query.PharmacyDocumentsQuery;
+
+import static org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryParameter.*;
+
+/**
+ * Base transformations for all PHARM-1 queries.
+ * @author Quentin Ligier
+ */
+abstract class PharmacyDocumentsQueryTransformer<T extends PharmacyDocumentsQuery> extends AbstractStoredQueryTransformer<T> {
+
+    /**
+     * Transforms the query into its ebXML representation.
+     * <p>
+     * Does not perform any transformation if one of the parameters is <code>null</code>.
+     * @param query
+     *          the query. Can be <code>null</code>.
+     * @param ebXML
+     *          the ebXML representation. Can be <code>null</code>.
+     */
+    public void toEbXML(T query, EbXMLAdhocQueryRequest ebXML) {
+        if (query == null || ebXML == null) {
+            return;
+        }
+
+        super.toEbXML(query, ebXML);
+        QuerySlotHelper slots = new QuerySlotHelper(ebXML);
+
+        slots.fromInteger(METADATA_LEVEL, query.getMetadataLevel());
+        slots.fromString(DOC_ENTRY_PATIENT_ID, Hl7v2Based.render(query.getPatientId()));
+        slots.fromStatus(DOC_ENTRY_STATUS, query.getStatus());
+    }
+
+    /**
+     * Transforms the ebXML representation of a query into a query object.
+     * <p>
+     * Does not perform any transformation if one of the parameters is <code>null</code>.
+     * @param query
+     *          the query. Can be <code>null</code>.
+     * @param ebXML
+     *          the ebXML representation. Can be <code>null</code>.
+     */
+    public void fromEbXML(T query, EbXMLAdhocQueryRequest ebXML) {
+        if (query == null || ebXML == null) {
+            return;
+        }
+
+        super.fromEbXML(query, ebXML);
+        QuerySlotHelper slots = new QuerySlotHelper(ebXML);
+
+        query.setMetadataLevel(slots.toInteger(METADATA_LEVEL));
+        query.setPatientId(Hl7v2Based.parse(slots.toString(DOC_ENTRY_PATIENT_ID), Identifiable.class));
+        query.setStatus(slots.toStatus(DOC_ENTRY_STATUS));
+    }
+}

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/validate/requests/AdhocQueryRequestValidator.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/validate/requests/AdhocQueryRequestValidator.java
@@ -31,8 +31,7 @@ import java.util.stream.Collectors;
 import static org.apache.commons.lang3.Validate.notNull;
 import static org.openehealth.ipf.commons.ihe.xds.XCA.Interactions.ITI_38;
 import static org.openehealth.ipf.commons.ihe.xds.XCF.Interactions.ITI_63;
-import static org.openehealth.ipf.commons.ihe.xds.XDS.Interactions.ITI_18;
-import static org.openehealth.ipf.commons.ihe.xds.XDS.Interactions.ITI_51;
+import static org.openehealth.ipf.commons.ihe.xds.XDS.Interactions.*;
 import static org.openehealth.ipf.commons.ihe.xds.core.requests.query.QueryType.*;
 import static org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryParameter.*;
 import static org.openehealth.ipf.commons.ihe.xds.core.validate.ValidationMessage.*;
@@ -93,6 +92,30 @@ public class AdhocQueryRequestValidator implements Validator<EbXMLAdhocQueryRequ
         addAllowedMultipleSlots(FETCH,
                 DOC_ENTRY_EVENT_CODE,
                 DOC_ENTRY_CONFIDENTIALITY_CODE);
+
+        addAllowedMultipleSlots(FIND_MEDICATION_TREATMENT_PLANS,
+                DOC_ENTRY_EVENT_CODE,
+                DOC_ENTRY_CONFIDENTIALITY_CODE);
+
+        addAllowedMultipleSlots(FIND_PRESCRIPTIONS,
+                DOC_ENTRY_EVENT_CODE,
+                DOC_ENTRY_CONFIDENTIALITY_CODE);
+
+        addAllowedMultipleSlots(FIND_DISPENSES,
+                DOC_ENTRY_EVENT_CODE,
+                DOC_ENTRY_CONFIDENTIALITY_CODE);
+
+        addAllowedMultipleSlots(FIND_MEDICATION_ADMINISTRATIONS,
+                DOC_ENTRY_EVENT_CODE,
+                DOC_ENTRY_CONFIDENTIALITY_CODE);
+
+        addAllowedMultipleSlots(FIND_PRESCRIPTIONS_FOR_VALIDATION,
+                DOC_ENTRY_EVENT_CODE,
+                DOC_ENTRY_CONFIDENTIALITY_CODE);
+
+        addAllowedMultipleSlots(FIND_PRESCRIPTIONS_FOR_DISPENSE,
+                DOC_ENTRY_EVENT_CODE,
+                DOC_ENTRY_CONFIDENTIALITY_CODE);
     }
 
 
@@ -113,13 +136,21 @@ public class AdhocQueryRequestValidator implements Validator<EbXMLAdhocQueryRequ
                 GET_SUBMISSION_SET_AND_CONTENTS,
                 GET_FOLDER_AND_CONTENTS,
                 GET_FOLDERS_FOR_DOCUMENT,
-                GET_RELATED_DOCUMENTS);
+                GET_RELATED_DOCUMENTS,
+                FIND_MEDICATION_TREATMENT_PLANS,
+                FIND_PRESCRIPTIONS,
+                FIND_DISPENSES,
+                FIND_MEDICATION_ADMINISTRATIONS,
+                FIND_PRESCRIPTIONS_FOR_VALIDATION,
+                FIND_PRESCRIPTIONS_FOR_DISPENSE,
+                FIND_MEDICATION_LIST);
 
         ALLOWED_QUERY_TYPES = new HashMap<>(5);
         ALLOWED_QUERY_TYPES.put(ITI_18, storedQueryTypes);
         ALLOWED_QUERY_TYPES.put(ITI_38, storedQueryTypes);
         ALLOWED_QUERY_TYPES.put(ITI_51, EnumSet.of(FIND_DOCUMENTS_MPQ, FIND_FOLDERS_MPQ));
         ALLOWED_QUERY_TYPES.put(ITI_63, EnumSet.of(FETCH));
+        ALLOWED_QUERY_TYPES.put(PHARM_1, storedQueryTypes);
     }
 
 
@@ -299,6 +330,43 @@ public class AdhocQueryRequestValidator implements Validator<EbXMLAdhocQueryRequ
                         new StringValidation(DOC_ENTRY_UUID, nopValidator, true),
                         new StringValidation(DOC_ENTRY_UNIQUE_ID, nopValidator, true),
                         new AssociationValidation(ASSOCIATION_TYPE),
+                        new DocumentEntryTypeValidation(),
+                };
+
+            case FIND_MEDICATION_TREATMENT_PLANS:
+            case FIND_PRESCRIPTIONS:
+            case FIND_DISPENSES:
+            case FIND_MEDICATION_ADMINISTRATIONS:
+            case FIND_PRESCRIPTIONS_FOR_VALIDATION:
+            case FIND_PRESCRIPTIONS_FOR_DISPENSE:
+                return new QueryParameterValidation[]{
+                        new StringValidation(DOC_ENTRY_PATIENT_ID, cxValidator, false),
+                        new ChoiceValidation(DOC_ENTRY_UUID, DOC_ENTRY_UNIQUE_ID),
+                        new StringListValidation(FOLDER_UUID, nopValidator),
+                        new StringListValidation(FOLDER_UNIQUE_ID, nopValidator),
+                        new CodeValidation(DOC_ENTRY_PRACTICE_SETTING_CODE),
+                        new NumberValidation(DOC_ENTRY_CREATION_TIME_FROM, timeValidator),
+                        new NumberValidation(DOC_ENTRY_CREATION_TIME_TO, timeValidator),
+                        new NumberValidation(DOC_ENTRY_SERVICE_START_TIME_FROM, timeValidator),
+                        new NumberValidation(DOC_ENTRY_SERVICE_START_TIME_TO, timeValidator),
+                        new NumberValidation(DOC_ENTRY_SERVICE_STOP_TIME_FROM, timeValidator),
+                        new NumberValidation(DOC_ENTRY_SERVICE_STOP_TIME_TO, timeValidator),
+                        new CodeValidation(DOC_ENTRY_HEALTHCARE_FACILITY_TYPE_CODE),
+                        new QueryListCodeValidation(DOC_ENTRY_EVENT_CODE, DOC_ENTRY_EVENT_CODE_SCHEME),
+                        new QueryListCodeValidation(DOC_ENTRY_CONFIDENTIALITY_CODE, DOC_ENTRY_CONFIDENTIALITY_CODE_SCHEME),
+                        new StringListValidation(DOC_ENTRY_AUTHOR_PERSON, nopValidator),
+                        new StatusValidation(DOC_ENTRY_STATUS),
+                };
+
+            case FIND_MEDICATION_LIST:
+                return new QueryParameterValidation[]{
+                        new StringValidation(DOC_ENTRY_PATIENT_ID, cxValidator, false),
+                        new NumberValidation(DOC_ENTRY_SERVICE_START_FROM, timeValidator),
+                        new NumberValidation(DOC_ENTRY_SERVICE_START_TO, timeValidator),
+                        new NumberValidation(DOC_ENTRY_SERVICE_END_FROM, timeValidator),
+                        new NumberValidation(DOC_ENTRY_SERVICE_END_TO, timeValidator),
+                        new QueryListCodeValidation(DOC_ENTRY_FORMAT_CODE, DOC_ENTRY_FORMAT_CODE_SCHEME),
+                        new StatusValidation(DOC_ENTRY_STATUS),
                         new DocumentEntryTypeValidation(),
                 };
         }

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/pharm1/Pharm1AuditStrategy.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/pharm1/Pharm1AuditStrategy.java
@@ -36,9 +36,9 @@ public class Pharm1AuditStrategy extends XdsQueryAuditStrategy30 {
 
     @Override
     public AuditMessage[] makeAuditMessage(AuditContext auditContext, XdsQueryAuditDataset auditDataset) {
-        return new XdsQueryInformationBuilder(auditContext, auditDataset, XdsEventTypeCode.RegistryStoredQuery, auditDataset.getPurposesOfUse())
+        return new XdsQueryInformationBuilder(auditContext, auditDataset, XdsEventTypeCode.QueryPharmacyDocuments, auditDataset.getPurposesOfUse())
                 .addPatients(auditDataset.getPatientId())
-                .setQueryParameters(auditDataset, XdsParticipantObjectIdTypeCode.RegistryStoredQuery)
+                .setQueryParameters(auditDataset, XdsParticipantObjectIdTypeCode.QueryPharmacyDocuments)
                 .getMessages();
     }
 }

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/pharm1/Pharm1AuditStrategy.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/pharm1/Pharm1AuditStrategy.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package org.openehealth.ipf.commons.ihe.xds.pharm1;
 
 import org.openehealth.ipf.commons.audit.AuditContext;
@@ -8,12 +23,22 @@ import org.openehealth.ipf.commons.ihe.xds.core.audit.codes.XdsEventTypeCode;
 import org.openehealth.ipf.commons.ihe.xds.core.audit.codes.XdsParticipantObjectIdTypeCode;
 import org.openehealth.ipf.commons.ihe.xds.core.audit.event.XdsQueryInformationBuilder;
 
+/**
+ * Client audit strategy for PHARM-1.
+ *
+ * @author Quentin Ligier
+ */
 public class Pharm1AuditStrategy extends XdsQueryAuditStrategy30 {
+
     public Pharm1AuditStrategy(boolean serverSide) {
         super(serverSide);
     }
 
+    @Override
     public AuditMessage[] makeAuditMessage(AuditContext auditContext, XdsQueryAuditDataset auditDataset) {
-        return ((XdsQueryInformationBuilder)(new XdsQueryInformationBuilder(auditContext, auditDataset, XdsEventTypeCode.RegistryStoredQuery, auditDataset.getPurposesOfUse())).addPatients(new String[]{auditDataset.getPatientId()})).setQueryParameters(auditDataset, XdsParticipantObjectIdTypeCode.RegistryStoredQuery).getMessages();
+        return new XdsQueryInformationBuilder(auditContext, auditDataset, XdsEventTypeCode.RegistryStoredQuery, auditDataset.getPurposesOfUse())
+                .addPatients(auditDataset.getPatientId())
+                .setQueryParameters(auditDataset, XdsParticipantObjectIdTypeCode.RegistryStoredQuery)
+                .getMessages();
     }
 }

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/pharm1/Pharm1AuditStrategy.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/pharm1/Pharm1AuditStrategy.java
@@ -1,0 +1,19 @@
+package org.openehealth.ipf.commons.ihe.xds.pharm1;
+
+import org.openehealth.ipf.commons.audit.AuditContext;
+import org.openehealth.ipf.commons.audit.model.AuditMessage;
+import org.openehealth.ipf.commons.ihe.xds.core.audit.XdsQueryAuditDataset;
+import org.openehealth.ipf.commons.ihe.xds.core.audit.XdsQueryAuditStrategy30;
+import org.openehealth.ipf.commons.ihe.xds.core.audit.codes.XdsEventTypeCode;
+import org.openehealth.ipf.commons.ihe.xds.core.audit.codes.XdsParticipantObjectIdTypeCode;
+import org.openehealth.ipf.commons.ihe.xds.core.audit.event.XdsQueryInformationBuilder;
+
+public class Pharm1AuditStrategy extends XdsQueryAuditStrategy30 {
+    public Pharm1AuditStrategy(boolean serverSide) {
+        super(serverSide);
+    }
+
+    public AuditMessage[] makeAuditMessage(AuditContext auditContext, XdsQueryAuditDataset auditDataset) {
+        return ((XdsQueryInformationBuilder)(new XdsQueryInformationBuilder(auditContext, auditDataset, XdsEventTypeCode.RegistryStoredQuery, auditDataset.getPurposesOfUse())).addPatients(new String[]{auditDataset.getPatientId()})).setQueryParameters(auditDataset, XdsParticipantObjectIdTypeCode.RegistryStoredQuery).getMessages();
+    }
+}

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/pharm1/Pharm1PortType.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/pharm1/Pharm1PortType.java
@@ -1,10 +1,24 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openehealth.ipf.commons.ihe.xds.pharm1;
 
 import org.apache.cxf.annotations.DataBinding;
 import org.openehealth.ipf.commons.ihe.xds.core.XdsJaxbDataBinding;
 import org.openehealth.ipf.commons.ihe.xds.core.stub.ebrs30.query.AdhocQueryRequest;
 import org.openehealth.ipf.commons.ihe.xds.core.stub.ebrs30.query.AdhocQueryResponse;
-import org.openehealth.ipf.commons.ihe.xds.core.stub.ebrs30.rim.ObjectFactory;
 
 import javax.jws.WebMethod;
 import javax.jws.WebParam;
@@ -14,17 +28,30 @@ import javax.jws.soap.SOAPBinding;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.ws.Action;
 
+/**
+ * Provides the PHARM-1 web-service interface.
+ */
 @WebService(
     targetNamespace = "urn:ihe:iti:xds-b:2007",
     name = "CommunityPharmacyManager_PortType",
     portName = "CommunityPharmacyManager_Port_Soap12"
 )
-@XmlSeeAlso({ObjectFactory.class, org.openehealth.ipf.commons.ihe.xds.core.stub.ebrs30.lcm.ObjectFactory.class, org.openehealth.ipf.commons.ihe.xds.core.stub.ebrs30.rs.ObjectFactory.class, org.openehealth.ipf.commons.ihe.xds.core.stub.ebrs30.query.ObjectFactory.class})
-@SOAPBinding(
-    parameterStyle = SOAPBinding.ParameterStyle.BARE
-)
+@XmlSeeAlso({
+        org.openehealth.ipf.commons.ihe.xds.core.stub.ebrs30.rim.ObjectFactory.class,
+        org.openehealth.ipf.commons.ihe.xds.core.stub.ebrs30.lcm.ObjectFactory.class,
+        org.openehealth.ipf.commons.ihe.xds.core.stub.ebrs30.rs.ObjectFactory.class,
+        org.openehealth.ipf.commons.ihe.xds.core.stub.ebrs30.query.ObjectFactory.class
+})
+@SOAPBinding(parameterStyle = SOAPBinding.ParameterStyle.BARE)
 @DataBinding(XdsJaxbDataBinding.class)
 public interface Pharm1PortType {
+
+    /**
+     * Performs a stored query according to the PHARM-1 specification.
+     * @param body
+     *          the query request.
+     * @return the query response.
+     */
     @WebResult(
         name = "AdhocQueryResponse",
         targetNamespace = "urn:oasis:names:tc:ebxml-regrep:xsd:query:3.0",
@@ -34,8 +61,11 @@ public interface Pharm1PortType {
         input = "urn:ihe:pharm:cmpd:2010:QueryPharmacyDocuments",
         output = "urn:ihe:pharm:cmpd:2010:QueryPharmacyDocumentsResponse"
     )
-    @WebMethod(
-        operationName = "CommunityPharmacyManager_QueryPharmacyDocuments"
-    )
-    AdhocQueryResponse communityPharmacyManagerQueryPharmacyDocuments(@WebParam(partName = "body", name = "AdhocQueryRequest", targetNamespace = "urn:oasis:names:tc:ebxml-regrep:xsd:query:3.0") AdhocQueryRequest var1);
+    @WebMethod(operationName = "CommunityPharmacyManager_QueryPharmacyDocuments")
+    AdhocQueryResponse communityPharmacyManagerQueryPharmacyDocuments(
+            @WebParam(
+                    partName = "body",
+                    name = "AdhocQueryRequest",
+                    targetNamespace = "urn:oasis:names:tc:ebxml-regrep:xsd:query:3.0") AdhocQueryRequest body
+    );
 }

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/pharm1/Pharm1PortType.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/pharm1/Pharm1PortType.java
@@ -1,0 +1,41 @@
+package org.openehealth.ipf.commons.ihe.xds.pharm1;
+
+import org.apache.cxf.annotations.DataBinding;
+import org.openehealth.ipf.commons.ihe.xds.core.XdsJaxbDataBinding;
+import org.openehealth.ipf.commons.ihe.xds.core.stub.ebrs30.query.AdhocQueryRequest;
+import org.openehealth.ipf.commons.ihe.xds.core.stub.ebrs30.query.AdhocQueryResponse;
+import org.openehealth.ipf.commons.ihe.xds.core.stub.ebrs30.rim.ObjectFactory;
+
+import javax.jws.WebMethod;
+import javax.jws.WebParam;
+import javax.jws.WebResult;
+import javax.jws.WebService;
+import javax.jws.soap.SOAPBinding;
+import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.ws.Action;
+
+@WebService(
+    targetNamespace = "urn:ihe:iti:xds-b:2007",
+    name = "CommunityPharmacyManager_PortType",
+    portName = "CommunityPharmacyManager_Port_Soap12"
+)
+@XmlSeeAlso({ObjectFactory.class, org.openehealth.ipf.commons.ihe.xds.core.stub.ebrs30.lcm.ObjectFactory.class, org.openehealth.ipf.commons.ihe.xds.core.stub.ebrs30.rs.ObjectFactory.class, org.openehealth.ipf.commons.ihe.xds.core.stub.ebrs30.query.ObjectFactory.class})
+@SOAPBinding(
+    parameterStyle = SOAPBinding.ParameterStyle.BARE
+)
+@DataBinding(XdsJaxbDataBinding.class)
+public interface Pharm1PortType {
+    @WebResult(
+        name = "AdhocQueryResponse",
+        targetNamespace = "urn:oasis:names:tc:ebxml-regrep:xsd:query:3.0",
+        partName = "body"
+    )
+    @Action(
+        input = "urn:ihe:pharm:cmpd:2010:QueryPharmacyDocuments",
+        output = "urn:ihe:pharm:cmpd:2010:QueryPharmacyDocumentsResponse"
+    )
+    @WebMethod(
+        operationName = "CommunityPharmacyManager_QueryPharmacyDocuments"
+    )
+    AdhocQueryResponse communityPharmacyManagerQueryPharmacyDocuments(@WebParam(partName = "body", name = "AdhocQueryRequest", targetNamespace = "urn:oasis:names:tc:ebxml-regrep:xsd:query:3.0") AdhocQueryRequest var1);
+}

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/pharm1/Pharm1PortType.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/pharm1/Pharm1PortType.java
@@ -66,6 +66,7 @@ public interface Pharm1PortType {
             @WebParam(
                     partName = "body",
                     name = "AdhocQueryRequest",
-                    targetNamespace = "urn:oasis:names:tc:ebxml-regrep:xsd:query:3.0") AdhocQueryRequest body
+                    targetNamespace = "urn:oasis:names:tc:ebxml-regrep:xsd:query:3.0")
+                    AdhocQueryRequest body
     );
 }

--- a/commons/ihe/xds/src/main/resources/wsdl/pharm1.wsdl
+++ b/commons/ihe/xds/src/main/resources/wsdl/pharm1.wsdl
@@ -35,7 +35,7 @@
         <part name="body" element="query:AdhocQueryRequest"/>
     </message>
 
-    <!-- TODO QueryPharmacyDocumentsResponse_Message or QueryPharmacyDocumentsResponse_Message ?? -->
+    <!-- TODO QueryPharmacyDocuments_Response_Message or QueryPharmacyDocumentsResponse_Message ?? -->
     <message name="QueryPharmacyDocumentsResponse_Message">
         <documentation>Query Pharmacy Documents Response</documentation>
         <part name="body" element="query:AdhocQueryResponse"/>

--- a/commons/ihe/xds/src/main/resources/wsdl/pharm1.wsdl
+++ b/commons/ihe/xds/src/main/resources/wsdl/pharm1.wsdl
@@ -22,7 +22,7 @@
     xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/"
     xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata">
 
-    <documentation>IHE XDS.b Document Registry = PHARM-1 adaptor = Registry Stored Query</documentation>
+    <documentation>IHE XDS.b Document Registry = PHARM-1 adaptor = Query Pharmacy Documents</documentation>
 
     <types>
         <xsd:schema elementFormDefault="qualified">
@@ -35,7 +35,7 @@
         <part name="body" element="query:AdhocQueryRequest"/>
     </message>
 
-    <!-- TODO QueryPharmacyDocuments_Response_Message or QueryPharmacyDocumentsResponse_Message ?? -->
+    <!-- TODO:QLIG QueryPharmacyDocuments_Response_Message or QueryPharmacyDocumentsResponse_Message ?? -->
     <message name="QueryPharmacyDocumentsResponse_Message">
         <documentation>Query Pharmacy Documents Response</documentation>
         <part name="body" element="query:AdhocQueryResponse"/>

--- a/commons/ihe/xds/src/main/resources/wsdl/pharm1.wsdl
+++ b/commons/ihe/xds/src/main/resources/wsdl/pharm1.wsdl
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+    Copyright 2009 the original author or authors. Licensed under the Apache
+    License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable
+    law or agreed to in writing, software distributed under the License is
+    distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the specific
+    language governing permissions and limitations under the License.
+-->
+
+<definitions
+    targetNamespace="urn:ihe:iti:xds-b:2007"
+    name="CommunityPharmacyManager"
+    xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+    xmlns="http://schemas.xmlsoap.org/wsdl/"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:ihe="urn:ihe:iti:xds-b:2007"
+    xmlns:query="urn:oasis:names:tc:ebxml-regrep:xsd:query:3.0"
+    xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/"
+    xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata">
+
+    <documentation>IHE XDS.b Document Registry = PHARM-1 adaptor = Registry Stored Query</documentation>
+
+    <types>
+        <xsd:schema elementFormDefault="qualified">
+            <xsd:import namespace="urn:oasis:names:tc:ebxml-regrep:xsd:query:3.0" schemaLocation="schema/ebRS30/query.xsd"/>
+        </xsd:schema>
+    </types>
+
+    <message name="QueryPharmacyDocuments_Message">
+        <documentation>Query Pharmacy Documents</documentation>
+        <part name="body" element="query:AdhocQueryRequest"/>
+    </message>
+
+    <!-- TODO QueryPharmacyDocumentsResponse_Message or QueryPharmacyDocumentsResponse_Message ?? -->
+    <message name="QueryPharmacyDocumentsResponse_Message">
+        <documentation>Query Pharmacy Documents Response</documentation>
+        <part name="body" element="query:AdhocQueryResponse"/>
+    </message>
+
+    <portType name="CommunityPharmacyManager_PortType">
+        <operation name="CommunityPharmacyManager_QueryPharmacyDocuments">
+            <input message="ihe:QueryPharmacyDocuments_Message"
+                   wsam:Action="urn:ihe:pharm:cmpd:2010:QueryPharmacyDocuments"/>
+            <output message="ihe:RegistryStoredQueryResponse_Message"
+                    wsam:Action="urn:ihe:pharm:cmpd:2010:QueryPharmacyDocumentsResponse"/>
+        </operation>
+    </portType>
+
+    <binding name="DocumentRegistry_Binding_Soap12" type="ihe:DocumentRegistry_PortType">
+        <soap12:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <operation name="DocumentRegistry_RegistryStoredQuery">
+            <soap12:operation soapActionRequired="false"/>
+            <input>
+                <soap12:body use="literal"/>
+            </input>
+            <output>
+                <soap12:body use="literal"/>
+            </output>
+        </operation>
+    </binding>
+
+    <binding name="DocumentRegistry_Binding_Soap11" type="ihe:DocumentRegistry_PortType">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <operation name="DocumentRegistry_RegistryStoredQuery">
+            <input>
+                <soap:body use="literal"/>
+            </input>
+            <output>
+                <soap:body use="literal"/>
+            </output>
+        </operation>
+    </binding>
+
+    <service name="CommunityPharmacyManager_Service">
+        <port name="CommunityPharmacyManager_Port_Soap12" binding="ihe:CommunityPharmacyManager_Binding_Soap12">
+            <soap12:address location="http://servicelocation/CommunityPharmacyManager_Service12"/>
+        </port>
+    </service>
+</definitions>

--- a/commons/ihe/xds/src/main/resources/wsdl/pharm1.wsdl
+++ b/commons/ihe/xds/src/main/resources/wsdl/pharm1.wsdl
@@ -35,7 +35,6 @@
         <part name="body" element="query:AdhocQueryRequest"/>
     </message>
 
-    <!-- TODO:QLIG QueryPharmacyDocuments_Response_Message or QueryPharmacyDocumentsResponse_Message ?? -->
     <message name="QueryPharmacyDocumentsResponse_Message">
         <documentation>Query Pharmacy Documents Response</documentation>
         <part name="body" element="query:AdhocQueryResponse"/>
@@ -45,32 +44,20 @@
         <operation name="CommunityPharmacyManager_QueryPharmacyDocuments">
             <input message="ihe:QueryPharmacyDocuments_Message"
                    wsam:Action="urn:ihe:pharm:cmpd:2010:QueryPharmacyDocuments"/>
-            <output message="ihe:RegistryStoredQueryResponse_Message"
+            <output message="ihe:QueryPharmacyDocumentsResponse_Message"
                     wsam:Action="urn:ihe:pharm:cmpd:2010:QueryPharmacyDocumentsResponse"/>
         </operation>
     </portType>
 
-    <binding name="DocumentRegistry_Binding_Soap12" type="ihe:DocumentRegistry_PortType">
+    <binding name="CommunityPharmacyManager_Binding_Soap12" type="ihe:CommunityPharmacyManager_PortType">
         <soap12:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
-        <operation name="DocumentRegistry_RegistryStoredQuery">
+        <operation name="CommunityPharmacyManager_QueryPharmacyDocuments">
             <soap12:operation soapActionRequired="false"/>
             <input>
                 <soap12:body use="literal"/>
             </input>
             <output>
                 <soap12:body use="literal"/>
-            </output>
-        </operation>
-    </binding>
-
-    <binding name="DocumentRegistry_Binding_Soap11" type="ihe:DocumentRegistry_PortType">
-        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
-        <operation name="DocumentRegistry_RegistryStoredQuery">
-            <input>
-                <soap:body use="literal"/>
-            </input>
-            <output>
-                <soap:body use="literal"/>
             </output>
         </operation>
     </binding>

--- a/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/SampleData.java
+++ b/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/SampleData.java
@@ -745,5 +745,93 @@ public abstract class SampleData {
         return removeDocs;
     }
 
+    /**
+     * @return a sample stored query to find dispenses.
+     */
+    public static QueryRegistry createFindDispensesQuery() {
+        final FindDispensesQuery query = new FindDispensesQuery();
+
+        query.setPatientId(new Identifiable("id3", new AssigningAuthority("1.3")));
+        query.setHomeCommunityId("12.21.41");
+        final QueryList<Code> confidentialityCodes = new QueryList<>();
+        confidentialityCodes.getOuterList().add(
+                Arrays.asList(new Code("code10", null, "scheme10"), new Code("code11", null, "scheme11")));
+        confidentialityCodes.getOuterList().add(
+                Collections.singletonList(new Code("code12", null, "scheme12")));
+        query.setConfidentialityCodes(confidentialityCodes);
+        query.getCreationTime().setFrom("1980");
+        query.getCreationTime().setTo("1981");
+        query.getServiceStartTime().setFrom("1982");
+        query.getServiceStartTime().setTo("1983");
+        query.getServiceStopTime().setFrom("1984");
+        query.getServiceStopTime().setTo("1985");
+        query.setStatus(Arrays.asList(AvailabilityStatus.APPROVED, AvailabilityStatus.SUBMITTED));
+        query.setUuids(Arrays.asList("uuid1", "uuid2"));
+        query.setPracticeSettingCodes(Arrays.asList(new Code("code3", null, "scheme3"), new Code("code4", null, "scheme4")));
+        query.setHealthcareFacilityTypeCodes(Arrays.asList(new Code("code5", null, "scheme5"), new Code("code6", null, "scheme6")));
+        final QueryList<Code> eventCodes = new QueryList<>();
+        eventCodes.getOuterList().add(
+                Arrays.asList(new Code("code7", null, "scheme7"), new Code("code8", null, "scheme8")));
+        eventCodes.getOuterList().add(
+                Collections.singletonList(new Code("code9", null, "scheme9")));
+        query.setEventCodes(eventCodes);
+        query.setAuthorPersons(Arrays.asList("per'son1", "person2"));
+
+        return new QueryRegistry(query);
+    }
+
+    /**
+     * @return a sample stored query to find prescriptions.
+     */
+    public static QueryRegistry createFindPrescriptionsQuery() {
+        final FindPrescriptionsQuery query = new FindPrescriptionsQuery();
+
+        query.setPatientId(new Identifiable("id3", new AssigningAuthority("1.3")));
+        query.setHomeCommunityId("urn:oid:1.2.3.14.15.926");
+        final QueryList<Code> confidentialityCodes = new QueryList<>();
+        confidentialityCodes.getOuterList().add(
+                Arrays.asList(new Code("code10", null, "scheme10"), new Code("code11", null, "scheme11")));
+        confidentialityCodes.getOuterList().add(
+                Collections.singletonList(new Code("code12", null, "scheme12")));
+        query.setConfidentialityCodes(confidentialityCodes);
+        query.getCreationTime().setFrom("1980");
+        query.getCreationTime().setTo("1981");
+        query.getServiceStartTime().setFrom("1982");
+        query.getServiceStartTime().setTo("1983");
+        query.getServiceStopTime().setFrom("1984");
+        query.getServiceStopTime().setTo("1985");
+        query.setStatus(Arrays.asList(AvailabilityStatus.APPROVED, AvailabilityStatus.SUBMITTED));
+        query.setUniqueIds(Arrays.asList("uniqueId1", "uniqueId2"));
+        query.setPracticeSettingCodes(Arrays.asList(new Code("code3", null, "scheme3"), new Code("code4", null, "scheme4")));
+        query.setHealthcareFacilityTypeCodes(Arrays.asList(new Code("code5", null, "scheme5"), new Code("code6", null, "scheme6")));
+        final QueryList<Code> eventCodes = new QueryList<>();
+        eventCodes.getOuterList().add(
+                Arrays.asList(new Code("code7", null, "scheme7"), new Code("code8", null, "scheme8")));
+        eventCodes.getOuterList().add(
+                Collections.singletonList(new Code("code9", null, "scheme9")));
+        query.setEventCodes(eventCodes);
+        query.setAuthorPersons(Arrays.asList("per'son1", "person2"));
+
+        return new QueryRegistry(query);
+    }
+
+    /**
+     * @return a sample stored query to find medication lists.
+     */
+    public static QueryRegistry createFindMedicationListQuery() {
+        final FindMedicationListQuery query = new FindMedicationListQuery();
+
+        query.setPatientId(new Identifiable("id3", new AssigningAuthority("1.3")));
+        query.setHomeCommunityId("12.21.41");
+        query.getServiceStart().setFrom("1982");
+        query.getServiceStart().setTo("1983");
+        query.getServiceEnd().setFrom("1984");
+        query.getServiceEnd().setTo("1985");
+        query.setStatus(Arrays.asList(AvailabilityStatus.APPROVED, AvailabilityStatus.SUBMITTED));
+        query.setFormatCodes(Arrays.asList(new Code("code13", null, "scheme13"), new Code("code14", null, "scheme14")));
+        query.setTypeCodes(Arrays.asList(new Code("codet1", null, "schemet1"), new Code("codet2", null, "schemet2")));
+
+        return new QueryRegistry(query);
+    }
 }
 

--- a/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/ebxml30/FindDispensesQueryTransformerTest.java
+++ b/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/ebxml30/FindDispensesQueryTransformerTest.java
@@ -17,6 +17,7 @@ package org.openehealth.ipf.commons.ihe.xds.core.transform.requests.ebxml30;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.openehealth.ipf.commons.ihe.xds.core.SampleData;
 import org.openehealth.ipf.commons.ihe.xds.core.ebxml.EbXMLAdhocQueryRequest;
 import org.openehealth.ipf.commons.ihe.xds.core.ebxml.EbXMLSlot;
 import org.openehealth.ipf.commons.ihe.xds.core.ebxml.ebxml30.EbXMLFactory30;
@@ -50,7 +51,7 @@ public class FindDispensesQueryTransformerTest {
         transformer = new FindDispensesQueryTransformer();
 
         query = new FindDispensesQuery();
-        query.setPatientId(new Identifiable("id1", new AssigningAuthority("uni1", "uniType1")));
+        query.setPatientId(new Identifiable("id3", new AssigningAuthority("uni3", "uniType3")));
         query.setHomeCommunityId("12.21.41");
         QueryList<Code> confidentialityCodes = new QueryList<>();
         confidentialityCodes.getOuterList().add(
@@ -86,7 +87,7 @@ public class FindDispensesQueryTransformerTest {
 
         assertEquals(QueryType.FIND_DISPENSES.getId(), ebXML.getId());
         assertEquals("12.21.41", ebXML.getHome());
-        assertEquals(Collections.singletonList("'id1^^^&uni1&uniType1'"),
+        assertEquals(Collections.singletonList("'id3^^^&uni3&uniType3'"),
                 ebXML.getSlotValues(QueryParameter.DOC_ENTRY_PATIENT_ID.getSlotName()));
         List<EbXMLSlot> confidentialitySlots = ebXML.getSlots(QueryParameter.DOC_ENTRY_CONFIDENTIALITY_CODE.getSlotName());
         assertEquals(2, confidentialitySlots.size());

--- a/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/ebxml30/FindDispensesQueryTransformerTest.java
+++ b/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/ebxml30/FindDispensesQueryTransformerTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openehealth.ipf.commons.ihe.xds.core.transform.requests.ebxml30;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openehealth.ipf.commons.ihe.xds.core.ebxml.EbXMLAdhocQueryRequest;
+import org.openehealth.ipf.commons.ihe.xds.core.ebxml.EbXMLSlot;
+import org.openehealth.ipf.commons.ihe.xds.core.ebxml.ebxml30.EbXMLFactory30;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.AssigningAuthority;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.AvailabilityStatus;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Code;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.query.FindDispensesQuery;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.query.QueryList;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.query.QueryType;
+import org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryParameter;
+import org.openehealth.ipf.commons.ihe.xds.core.transform.requests.query.FindDispensesQueryTransformer;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link FindDispensesQueryTransformer}.
+ * @author Quentin Ligier
+ */
+public class FindDispensesQueryTransformerTest {
+    private FindDispensesQueryTransformer transformer;
+    private FindDispensesQuery query;
+    private EbXMLAdhocQueryRequest ebXML;
+
+    @Before
+    public void setUp() {
+        transformer = new FindDispensesQueryTransformer();
+
+        query = new FindDispensesQuery();
+        query.setPatientId(new Identifiable("id1", new AssigningAuthority("uni1", "uniType1")));
+        query.setHomeCommunityId("12.21.41");
+        QueryList<Code> confidentialityCodes = new QueryList<>();
+        confidentialityCodes.getOuterList().add(
+                Arrays.asList(new Code("code10", null, "scheme10"), new Code("code11", null, "scheme11")));
+        confidentialityCodes.getOuterList().add(
+                Collections.singletonList(new Code("code12", null, "scheme12")));
+        query.setConfidentialityCodes(confidentialityCodes);
+        query.getCreationTime().setFrom("1980");
+        query.getCreationTime().setTo("1981");
+        query.getServiceStartTime().setFrom("1982");
+        query.getServiceStartTime().setTo("1983");
+        query.getServiceStopTime().setFrom("1984");
+        query.getServiceStopTime().setTo("1985");
+        query.setStatus(Arrays.asList(AvailabilityStatus.APPROVED, AvailabilityStatus.SUBMITTED));
+        query.setUuids(Arrays.asList("uuid1", "uuid2"));
+        query.setUniqueIds(Arrays.asList("uniqueId1", "uniqueId2"));
+        query.setPracticeSettingCodes(Arrays.asList(new Code("code3", null, "scheme3"), new Code("code4", null, "scheme4")));
+        query.setHealthcareFacilityTypeCodes(Arrays.asList(new Code("code5", null, "scheme5"), new Code("code6", null, "scheme6")));
+        QueryList<Code> eventCodes = new QueryList<>();
+        eventCodes.getOuterList().add(
+                Arrays.asList(new Code("code7", null, "scheme7"), new Code("code8", null, "scheme8")));
+        eventCodes.getOuterList().add(
+                Collections.singletonList(new Code("code9", null, "scheme9")));
+        query.setEventCodes(eventCodes);
+        query.setAuthorPersons(Arrays.asList("per'son1", "person2"));
+
+        ebXML = new EbXMLFactory30().createAdhocQueryRequest();
+    }
+
+    @Test
+    public void testToEbXML() {
+        transformer.toEbXML(query, ebXML);
+
+        assertEquals(QueryType.FIND_DISPENSES.getId(), ebXML.getId());
+        assertEquals("12.21.41", ebXML.getHome());
+        assertEquals(Collections.singletonList("'id1^^^&uni1&uniType1'"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_PATIENT_ID.getSlotName()));
+        List<EbXMLSlot> confidentialitySlots = ebXML.getSlots(QueryParameter.DOC_ENTRY_CONFIDENTIALITY_CODE.getSlotName());
+        assertEquals(2, confidentialitySlots.size());
+        assertEquals(Arrays.asList("('code10^^scheme10')", "('code11^^scheme11')"), confidentialitySlots.get(0).getValueList());
+        assertEquals(Collections.singletonList("('code12^^scheme12')"), confidentialitySlots.get(1).getValueList());
+        assertEquals(Collections.singletonList("1980"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_CREATION_TIME_FROM.getSlotName()));
+        assertEquals(Collections.singletonList("1981"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_CREATION_TIME_TO.getSlotName()));
+        assertEquals(Collections.singletonList("1982"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_SERVICE_START_TIME_FROM.getSlotName()));
+        assertEquals(Collections.singletonList("1983"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_SERVICE_START_TIME_TO.getSlotName()));
+        assertEquals(Collections.singletonList("1984"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_SERVICE_STOP_TIME_FROM.getSlotName()));
+        assertEquals(Collections.singletonList("1985"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_SERVICE_STOP_TIME_TO.getSlotName()));
+        assertEquals(Arrays.asList("('urn:oasis:names:tc:ebxml-regrep:StatusType:Approved')", "('urn:oasis:names:tc:ebxml-regrep:StatusType:Submitted')"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_STATUS.getSlotName()));
+        assertEquals(Arrays.asList("('uuid1')", "('uuid2')"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_UUID.getSlotName()));
+        assertEquals(Arrays.asList("('uniqueId1')", "('uniqueId2')"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_UNIQUE_ID.getSlotName()));
+        assertEquals(Arrays.asList("('code3^^scheme3')", "('code4^^scheme4')"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_PRACTICE_SETTING_CODE.getSlotName()));
+        assertEquals(Arrays.asList("('code5^^scheme5')", "('code6^^scheme6')"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_HEALTHCARE_FACILITY_TYPE_CODE.getSlotName()));
+        List<EbXMLSlot> eventSlots = ebXML.getSlots(QueryParameter.DOC_ENTRY_EVENT_CODE.getSlotName());
+        assertEquals(2, eventSlots.size());
+        assertEquals(Arrays.asList("('code7^^scheme7')", "('code8^^scheme8')"), eventSlots.get(0).getValueList());
+        assertEquals(Collections.singletonList("('code9^^scheme9')"), eventSlots.get(1).getValueList());
+        assertEquals(Arrays.asList("('per''son1')", "('person2')"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_AUTHOR_PERSON.getSlotName()));
+    }
+
+    @Test
+    public void testToEbXMLNull() {
+        transformer.toEbXML(null, ebXML);
+        assertEquals(0, ebXML.getSlots().size());
+    }
+
+    @Test
+    public void testToEbXMLEmpty() {
+        transformer.toEbXML(new FindDispensesQuery(), ebXML);
+        assertEquals(0, ebXML.getSlots().size());
+    }
+
+    @Test
+    public void testFromEbXML() {
+        transformer.toEbXML(query, ebXML);
+        FindDispensesQuery result = new FindDispensesQuery();
+        transformer.fromEbXML(result, ebXML);
+        assertEquals(query, result);
+    }
+
+    @Test
+    public void testFromEbXMLNull() {
+        FindDispensesQuery result = new FindDispensesQuery();
+        transformer.fromEbXML(result, null);
+        assertEquals(new FindDispensesQuery(), result);
+    }
+
+    @Test
+    public void testFromEbXMLEmpty() {
+        FindDispensesQuery result = new FindDispensesQuery();
+        transformer.fromEbXML(result, ebXML);
+        assertEquals(new FindDispensesQuery(), result);
+    }
+}

--- a/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/ebxml30/FindMedicationAdministrationsTransformerTest.java
+++ b/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/ebxml30/FindMedicationAdministrationsTransformerTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openehealth.ipf.commons.ihe.xds.core.transform.requests.ebxml30;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openehealth.ipf.commons.ihe.xds.core.ebxml.EbXMLAdhocQueryRequest;
+import org.openehealth.ipf.commons.ihe.xds.core.ebxml.EbXMLSlot;
+import org.openehealth.ipf.commons.ihe.xds.core.ebxml.ebxml30.EbXMLFactory30;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.AssigningAuthority;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.AvailabilityStatus;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Code;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.query.FindMedicationAdministrationsQuery;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.query.QueryList;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.query.QueryType;
+import org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryParameter;
+import org.openehealth.ipf.commons.ihe.xds.core.transform.requests.query.FindMedicationAdministrationsQueryTransformer;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link FindMedicationAdministrationsQueryTransformer}.
+ * @author Quentin Ligier
+ */
+public class FindMedicationAdministrationsTransformerTest {
+    private FindMedicationAdministrationsQueryTransformer transformer;
+    private FindMedicationAdministrationsQuery query;
+    private EbXMLAdhocQueryRequest ebXML;
+
+    @Before
+    public void setUp() {
+        transformer = new FindMedicationAdministrationsQueryTransformer();
+
+        query = new FindMedicationAdministrationsQuery();
+        query.setPatientId(new Identifiable("id1", new AssigningAuthority("uni1", "uniType1")));
+        query.setHomeCommunityId("12.21.41");
+        QueryList<Code> confidentialityCodes = new QueryList<>();
+        confidentialityCodes.getOuterList().add(
+                Arrays.asList(new Code("code10", null, "scheme10"), new Code("code11", null, "scheme11")));
+        confidentialityCodes.getOuterList().add(
+                Collections.singletonList(new Code("code12", null, "scheme12")));
+        query.setConfidentialityCodes(confidentialityCodes);
+        query.getCreationTime().setFrom("1980");
+        query.getCreationTime().setTo("1981");
+        query.getServiceStartTime().setFrom("1982");
+        query.getServiceStartTime().setTo("1983");
+        query.getServiceStopTime().setFrom("1984");
+        query.getServiceStopTime().setTo("1985");
+        query.setStatus(Arrays.asList(AvailabilityStatus.APPROVED, AvailabilityStatus.SUBMITTED));
+        query.setUuids(Arrays.asList("uuid1", "uuid2"));
+        query.setUniqueIds(Arrays.asList("uniqueId1", "uniqueId2"));
+        query.setPracticeSettingCodes(Arrays.asList(new Code("code3", null, "scheme3"), new Code("code4", null, "scheme4")));
+        query.setHealthcareFacilityTypeCodes(Arrays.asList(new Code("code5", null, "scheme5"), new Code("code6", null, "scheme6")));
+        QueryList<Code> eventCodes = new QueryList<>();
+        eventCodes.getOuterList().add(
+                Arrays.asList(new Code("code7", null, "scheme7"), new Code("code8", null, "scheme8")));
+        eventCodes.getOuterList().add(
+                Collections.singletonList(new Code("code9", null, "scheme9")));
+        query.setEventCodes(eventCodes);
+        query.setAuthorPersons(Arrays.asList("per'son1", "person2"));
+
+        ebXML = new EbXMLFactory30().createAdhocQueryRequest();
+    }
+
+    @Test
+    public void testToEbXML() {
+        transformer.toEbXML(query, ebXML);
+
+        assertEquals(QueryType.FIND_MEDICATION_ADMINISTRATIONS.getId(), ebXML.getId());
+        assertEquals("12.21.41", ebXML.getHome());
+        assertEquals(Collections.singletonList("'id1^^^&uni1&uniType1'"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_PATIENT_ID.getSlotName()));
+        List<EbXMLSlot> confidentialitySlots = ebXML.getSlots(QueryParameter.DOC_ENTRY_CONFIDENTIALITY_CODE.getSlotName());
+        assertEquals(2, confidentialitySlots.size());
+        assertEquals(Arrays.asList("('code10^^scheme10')", "('code11^^scheme11')"), confidentialitySlots.get(0).getValueList());
+        assertEquals(Collections.singletonList("('code12^^scheme12')"), confidentialitySlots.get(1).getValueList());
+        assertEquals(Collections.singletonList("1980"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_CREATION_TIME_FROM.getSlotName()));
+        assertEquals(Collections.singletonList("1981"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_CREATION_TIME_TO.getSlotName()));
+        assertEquals(Collections.singletonList("1982"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_SERVICE_START_TIME_FROM.getSlotName()));
+        assertEquals(Collections.singletonList("1983"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_SERVICE_START_TIME_TO.getSlotName()));
+        assertEquals(Collections.singletonList("1984"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_SERVICE_STOP_TIME_FROM.getSlotName()));
+        assertEquals(Collections.singletonList("1985"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_SERVICE_STOP_TIME_TO.getSlotName()));
+        assertEquals(Arrays.asList("('urn:oasis:names:tc:ebxml-regrep:StatusType:Approved')", "('urn:oasis:names:tc:ebxml-regrep:StatusType:Submitted')"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_STATUS.getSlotName()));
+        assertEquals(Arrays.asList("('uuid1')", "('uuid2')"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_UUID.getSlotName()));
+        assertEquals(Arrays.asList("('uniqueId1')", "('uniqueId2')"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_UNIQUE_ID.getSlotName()));
+        assertEquals(Arrays.asList("('code3^^scheme3')", "('code4^^scheme4')"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_PRACTICE_SETTING_CODE.getSlotName()));
+        assertEquals(Arrays.asList("('code5^^scheme5')", "('code6^^scheme6')"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_HEALTHCARE_FACILITY_TYPE_CODE.getSlotName()));
+        List<EbXMLSlot> eventSlots = ebXML.getSlots(QueryParameter.DOC_ENTRY_EVENT_CODE.getSlotName());
+        assertEquals(2, eventSlots.size());
+        assertEquals(Arrays.asList("('code7^^scheme7')", "('code8^^scheme8')"), eventSlots.get(0).getValueList());
+        assertEquals(Collections.singletonList("('code9^^scheme9')"), eventSlots.get(1).getValueList());
+        assertEquals(Arrays.asList("('per''son1')", "('person2')"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_AUTHOR_PERSON.getSlotName()));
+    }
+
+    @Test
+    public void testToEbXMLNull() {
+        transformer.toEbXML(null, ebXML);
+        assertEquals(0, ebXML.getSlots().size());
+    }
+
+    @Test
+    public void testToEbXMLEmpty() {
+        transformer.toEbXML(new FindMedicationAdministrationsQuery(), ebXML);
+        assertEquals(0, ebXML.getSlots().size());
+    }
+
+    @Test
+    public void testFromEbXML() {
+        transformer.toEbXML(query, ebXML);
+        FindMedicationAdministrationsQuery result = new FindMedicationAdministrationsQuery();
+        transformer.fromEbXML(result, ebXML);
+        assertEquals(query, result);
+    }
+
+    @Test
+    public void testFromEbXMLNull() {
+        FindMedicationAdministrationsQuery result = new FindMedicationAdministrationsQuery();
+        transformer.fromEbXML(result, null);
+        assertEquals(new FindMedicationAdministrationsQuery(), result);
+    }
+
+    @Test
+    public void testFromEbXMLEmpty() {
+        FindMedicationAdministrationsQuery result = new FindMedicationAdministrationsQuery();
+        transformer.fromEbXML(result, ebXML);
+        assertEquals(new FindMedicationAdministrationsQuery(), result);
+    }
+}

--- a/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/ebxml30/FindMedicationListQueryTransformerTest.java
+++ b/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/ebxml30/FindMedicationListQueryTransformerTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openehealth.ipf.commons.ihe.xds.core.transform.requests.ebxml30;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openehealth.ipf.commons.ihe.xds.core.ebxml.EbXMLAdhocQueryRequest;
+import org.openehealth.ipf.commons.ihe.xds.core.ebxml.ebxml30.EbXMLFactory30;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.AssigningAuthority;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.AvailabilityStatus;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Code;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.query.FindMedicationListQuery;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.query.QueryType;
+import org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryParameter;
+import org.openehealth.ipf.commons.ihe.xds.core.transform.requests.query.FindMedicationListQueryTransformer;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link FindMedicationListQueryTransformer}.
+ * @author Quentin Ligier
+ */
+public class FindMedicationListQueryTransformerTest {
+    private FindMedicationListQueryTransformer transformer;
+    private FindMedicationListQuery query;
+    private EbXMLAdhocQueryRequest ebXML;
+
+    @Before
+    public void setUp() {
+        transformer = new FindMedicationListQueryTransformer();
+
+        query = new FindMedicationListQuery();
+        query.setPatientId(new Identifiable("id1", new AssigningAuthority("uni1", "uniType1")));
+        query.setHomeCommunityId("12.21.41");
+        query.getServiceStart().setFrom("1982");
+        query.getServiceStart().setTo("1983");
+        query.getServiceEnd().setFrom("1984");
+        query.getServiceEnd().setTo("1985");
+        query.setStatus(Arrays.asList(AvailabilityStatus.APPROVED, AvailabilityStatus.SUBMITTED));
+        query.setFormatCodes(Arrays.asList(new Code("code13", null, "scheme13"), new Code("code14", null, "scheme14")));
+        query.setTypeCodes(Arrays.asList(new Code("codet1", null, "schemet1"), new Code("codet2", null, "schemet2")));
+
+        ebXML = new EbXMLFactory30().createAdhocQueryRequest();
+    }
+
+    @Test
+    public void testToEbXML() {
+        transformer.toEbXML(query, ebXML);
+
+        assertEquals(QueryType.FIND_MEDICATION_LIST.getId(), ebXML.getId());
+        assertEquals("12.21.41", ebXML.getHome());
+        assertEquals(Collections.singletonList("'id1^^^&uni1&uniType1'"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_PATIENT_ID.getSlotName()));
+        assertEquals(Collections.singletonList("1982"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_SERVICE_START_FROM.getSlotName()));
+        assertEquals(Collections.singletonList("1983"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_SERVICE_START_TO.getSlotName()));
+        assertEquals(Collections.singletonList("1984"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_SERVICE_END_FROM.getSlotName()));
+        assertEquals(Collections.singletonList("1985"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_SERVICE_END_TO.getSlotName()));
+        assertEquals(Arrays.asList("('urn:oasis:names:tc:ebxml-regrep:StatusType:Approved')", "('urn:oasis:names:tc:ebxml-regrep:StatusType:Submitted')"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_STATUS.getSlotName()));
+        assertEquals(Arrays.asList("('code13^^scheme13')", "('code14^^scheme14')"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_FORMAT_CODE.getSlotName()));
+        assertEquals(Arrays.asList("('codet1^^schemet1')", "('codet2^^schemet2')"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_TYPE_CODE.getSlotName()));
+    }
+
+    @Test
+    public void testToEbXMLNull() {
+        transformer.toEbXML(null, ebXML);
+        assertEquals(0, ebXML.getSlots().size());
+    }
+
+    @Test
+    public void testToEbXMLEmpty() {
+        transformer.toEbXML(new FindMedicationListQuery(), ebXML);
+        assertEquals(0, ebXML.getSlots().size());
+    }
+
+    @Test
+    public void testFromEbXML() {
+        transformer.toEbXML(query, ebXML);
+        FindMedicationListQuery result = new FindMedicationListQuery();
+        transformer.fromEbXML(result, ebXML);
+        assertEquals(query, result);
+    }
+
+    @Test
+    public void testFromEbXMLNull() {
+        FindMedicationListQuery result = new FindMedicationListQuery();
+        transformer.fromEbXML(result, null);
+        assertEquals(new FindMedicationListQuery(), result);
+    }
+
+    @Test
+    public void testFromEbXMLEmpty() {
+        FindMedicationListQuery result = new FindMedicationListQuery();
+        transformer.fromEbXML(result, ebXML);
+        assertEquals(new FindMedicationListQuery(), result);
+    }
+}

--- a/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/ebxml30/FindMedicationTreatmentPlansQueryTransformerTest.java
+++ b/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/ebxml30/FindMedicationTreatmentPlansQueryTransformerTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openehealth.ipf.commons.ihe.xds.core.transform.requests.ebxml30;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openehealth.ipf.commons.ihe.xds.core.ebxml.EbXMLAdhocQueryRequest;
+import org.openehealth.ipf.commons.ihe.xds.core.ebxml.EbXMLSlot;
+import org.openehealth.ipf.commons.ihe.xds.core.ebxml.ebxml30.EbXMLFactory30;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.AssigningAuthority;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.AvailabilityStatus;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Code;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.query.FindMedicationTreatmentPlansQuery;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.query.QueryList;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.query.QueryType;
+import org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryParameter;
+import org.openehealth.ipf.commons.ihe.xds.core.transform.requests.query.FindMedicationTreatmentPlansQueryTransformer;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link FindMedicationTreatmentPlansQueryTransformer}.
+ * @author Quentin Ligier
+ */
+public class FindMedicationTreatmentPlansQueryTransformerTest {
+    private FindMedicationTreatmentPlansQueryTransformer transformer;
+    private FindMedicationTreatmentPlansQuery query;
+    private EbXMLAdhocQueryRequest ebXML;
+
+    @Before
+    public void setUp() {
+        transformer = new FindMedicationTreatmentPlansQueryTransformer();
+
+        query = new FindMedicationTreatmentPlansQuery();
+        query.setPatientId(new Identifiable("id1", new AssigningAuthority("uni1", "uniType1")));
+        query.setHomeCommunityId("12.21.41");
+        QueryList<Code> confidentialityCodes = new QueryList<>();
+        confidentialityCodes.getOuterList().add(
+                Arrays.asList(new Code("code10", null, "scheme10"), new Code("code11", null, "scheme11")));
+        confidentialityCodes.getOuterList().add(
+                Collections.singletonList(new Code("code12", null, "scheme12")));
+        query.setConfidentialityCodes(confidentialityCodes);
+        query.getCreationTime().setFrom("1980");
+        query.getCreationTime().setTo("1981");
+        query.getServiceStartTime().setFrom("1982");
+        query.getServiceStartTime().setTo("1983");
+        query.getServiceStopTime().setFrom("1984");
+        query.getServiceStopTime().setTo("1985");
+        query.setStatus(Arrays.asList(AvailabilityStatus.APPROVED, AvailabilityStatus.SUBMITTED));
+        query.setUuids(Arrays.asList("uuid1", "uuid2"));
+        query.setUniqueIds(Arrays.asList("uniqueId1", "uniqueId2"));
+        query.setPracticeSettingCodes(Arrays.asList(new Code("code3", null, "scheme3"), new Code("code4", null, "scheme4")));
+        query.setHealthcareFacilityTypeCodes(Arrays.asList(new Code("code5", null, "scheme5"), new Code("code6", null, "scheme6")));
+        QueryList<Code> eventCodes = new QueryList<>();
+        eventCodes.getOuterList().add(
+                Arrays.asList(new Code("code7", null, "scheme7"), new Code("code8", null, "scheme8")));
+        eventCodes.getOuterList().add(
+                Collections.singletonList(new Code("code9", null, "scheme9")));
+        query.setEventCodes(eventCodes);
+        query.setAuthorPersons(Arrays.asList("per'son1", "person2"));
+
+        ebXML = new EbXMLFactory30().createAdhocQueryRequest();
+    }
+
+    @Test
+    public void testToEbXML() {
+        transformer.toEbXML(query, ebXML);
+
+        assertEquals(QueryType.FIND_MEDICATION_TREATMENT_PLANS.getId(), ebXML.getId());
+        assertEquals("12.21.41", ebXML.getHome());
+        assertEquals(Collections.singletonList("'id1^^^&uni1&uniType1'"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_PATIENT_ID.getSlotName()));
+        List<EbXMLSlot> confidentialitySlots = ebXML.getSlots(QueryParameter.DOC_ENTRY_CONFIDENTIALITY_CODE.getSlotName());
+        assertEquals(2, confidentialitySlots.size());
+        assertEquals(Arrays.asList("('code10^^scheme10')", "('code11^^scheme11')"), confidentialitySlots.get(0).getValueList());
+        assertEquals(Collections.singletonList("('code12^^scheme12')"), confidentialitySlots.get(1).getValueList());
+        assertEquals(Collections.singletonList("1980"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_CREATION_TIME_FROM.getSlotName()));
+        assertEquals(Collections.singletonList("1981"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_CREATION_TIME_TO.getSlotName()));
+        assertEquals(Collections.singletonList("1982"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_SERVICE_START_TIME_FROM.getSlotName()));
+        assertEquals(Collections.singletonList("1983"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_SERVICE_START_TIME_TO.getSlotName()));
+        assertEquals(Collections.singletonList("1984"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_SERVICE_STOP_TIME_FROM.getSlotName()));
+        assertEquals(Collections.singletonList("1985"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_SERVICE_STOP_TIME_TO.getSlotName()));
+        assertEquals(Arrays.asList("('urn:oasis:names:tc:ebxml-regrep:StatusType:Approved')", "('urn:oasis:names:tc:ebxml-regrep:StatusType:Submitted')"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_STATUS.getSlotName()));
+        assertEquals(Arrays.asList("('uuid1')", "('uuid2')"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_UUID.getSlotName()));
+        assertEquals(Arrays.asList("('uniqueId1')", "('uniqueId2')"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_UNIQUE_ID.getSlotName()));
+        assertEquals(Arrays.asList("('code3^^scheme3')", "('code4^^scheme4')"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_PRACTICE_SETTING_CODE.getSlotName()));
+        assertEquals(Arrays.asList("('code5^^scheme5')", "('code6^^scheme6')"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_HEALTHCARE_FACILITY_TYPE_CODE.getSlotName()));
+        List<EbXMLSlot> eventSlots = ebXML.getSlots(QueryParameter.DOC_ENTRY_EVENT_CODE.getSlotName());
+        assertEquals(2, eventSlots.size());
+        assertEquals(Arrays.asList("('code7^^scheme7')", "('code8^^scheme8')"), eventSlots.get(0).getValueList());
+        assertEquals(Collections.singletonList("('code9^^scheme9')"), eventSlots.get(1).getValueList());
+        assertEquals(Arrays.asList("('per''son1')", "('person2')"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_AUTHOR_PERSON.getSlotName()));
+    }
+
+    @Test
+    public void testToEbXMLNull() {
+        transformer.toEbXML(null, ebXML);
+        assertEquals(0, ebXML.getSlots().size());
+    }
+
+    @Test
+    public void testToEbXMLEmpty() {
+        transformer.toEbXML(new FindMedicationTreatmentPlansQuery(), ebXML);
+        assertEquals(0, ebXML.getSlots().size());
+    }
+
+    @Test
+    public void testFromEbXML() {
+        transformer.toEbXML(query, ebXML);
+        FindMedicationTreatmentPlansQuery result = new FindMedicationTreatmentPlansQuery();
+        transformer.fromEbXML(result, ebXML);
+        assertEquals(query, result);
+    }
+
+    @Test
+    public void testFromEbXMLNull() {
+        FindMedicationTreatmentPlansQuery result = new FindMedicationTreatmentPlansQuery();
+        transformer.fromEbXML(result, null);
+        assertEquals(new FindMedicationTreatmentPlansQuery(), result);
+    }
+
+    @Test
+    public void testFromEbXMLEmpty() {
+        FindMedicationTreatmentPlansQuery result = new FindMedicationTreatmentPlansQuery();
+        transformer.fromEbXML(result, ebXML);
+        assertEquals(new FindMedicationTreatmentPlansQuery(), result);
+    }
+}

--- a/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/ebxml30/FindPrescriptionsForDispenseQueryTransformerTest.java
+++ b/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/ebxml30/FindPrescriptionsForDispenseQueryTransformerTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openehealth.ipf.commons.ihe.xds.core.transform.requests.ebxml30;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openehealth.ipf.commons.ihe.xds.core.ebxml.EbXMLAdhocQueryRequest;
+import org.openehealth.ipf.commons.ihe.xds.core.ebxml.EbXMLSlot;
+import org.openehealth.ipf.commons.ihe.xds.core.ebxml.ebxml30.EbXMLFactory30;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.AssigningAuthority;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.AvailabilityStatus;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Code;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.query.FindPrescriptionsForDispenseQuery;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.query.QueryList;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.query.QueryType;
+import org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryParameter;
+import org.openehealth.ipf.commons.ihe.xds.core.transform.requests.query.FindPrescriptionsForDispenseQueryTransformer;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link FindPrescriptionsForDispenseQueryTransformer}.
+ * @author Quentin Ligier
+ */
+public class FindPrescriptionsForDispenseQueryTransformerTest {
+    private FindPrescriptionsForDispenseQueryTransformer transformer;
+    private FindPrescriptionsForDispenseQuery query;
+    private EbXMLAdhocQueryRequest ebXML;
+
+    @Before
+    public void setUp() {
+        transformer = new FindPrescriptionsForDispenseQueryTransformer();
+
+        query = new FindPrescriptionsForDispenseQuery();
+        query.setPatientId(new Identifiable("id1", new AssigningAuthority("uni1", "uniType1")));
+        query.setHomeCommunityId("12.21.41");
+        QueryList<Code> confidentialityCodes = new QueryList<>();
+        confidentialityCodes.getOuterList().add(
+                Arrays.asList(new Code("code10", null, "scheme10"), new Code("code11", null, "scheme11")));
+        confidentialityCodes.getOuterList().add(
+                Collections.singletonList(new Code("code12", null, "scheme12")));
+        query.setConfidentialityCodes(confidentialityCodes);
+        query.getCreationTime().setFrom("1980");
+        query.getCreationTime().setTo("1981");
+        query.getServiceStartTime().setFrom("1982");
+        query.getServiceStartTime().setTo("1983");
+        query.getServiceStopTime().setFrom("1984");
+        query.getServiceStopTime().setTo("1985");
+        query.setStatus(Arrays.asList(AvailabilityStatus.APPROVED, AvailabilityStatus.SUBMITTED));
+        query.setUuids(Arrays.asList("uuid1", "uuid2"));
+        query.setUniqueIds(Arrays.asList("uniqueId1", "uniqueId2"));
+        query.setPracticeSettingCodes(Arrays.asList(new Code("code3", null, "scheme3"), new Code("code4", null, "scheme4")));
+        query.setHealthcareFacilityTypeCodes(Arrays.asList(new Code("code5", null, "scheme5"), new Code("code6", null, "scheme6")));
+        QueryList<Code> eventCodes = new QueryList<>();
+        eventCodes.getOuterList().add(
+                Arrays.asList(new Code("code7", null, "scheme7"), new Code("code8", null, "scheme8")));
+        eventCodes.getOuterList().add(
+                Collections.singletonList(new Code("code9", null, "scheme9")));
+        query.setEventCodes(eventCodes);
+        query.setAuthorPersons(Arrays.asList("per'son1", "person2"));
+
+        ebXML = new EbXMLFactory30().createAdhocQueryRequest();
+    }
+
+    @Test
+    public void testToEbXML() {
+        transformer.toEbXML(query, ebXML);
+
+        assertEquals(QueryType.FIND_PRESCRIPTIONS_FOR_DISPENSE.getId(), ebXML.getId());
+        assertEquals("12.21.41", ebXML.getHome());
+        assertEquals(Collections.singletonList("'id1^^^&uni1&uniType1'"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_PATIENT_ID.getSlotName()));
+        List<EbXMLSlot> confidentialitySlots = ebXML.getSlots(QueryParameter.DOC_ENTRY_CONFIDENTIALITY_CODE.getSlotName());
+        assertEquals(2, confidentialitySlots.size());
+        assertEquals(Arrays.asList("('code10^^scheme10')", "('code11^^scheme11')"), confidentialitySlots.get(0).getValueList());
+        assertEquals(Collections.singletonList("('code12^^scheme12')"), confidentialitySlots.get(1).getValueList());
+        assertEquals(Collections.singletonList("1980"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_CREATION_TIME_FROM.getSlotName()));
+        assertEquals(Collections.singletonList("1981"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_CREATION_TIME_TO.getSlotName()));
+        assertEquals(Collections.singletonList("1982"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_SERVICE_START_TIME_FROM.getSlotName()));
+        assertEquals(Collections.singletonList("1983"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_SERVICE_START_TIME_TO.getSlotName()));
+        assertEquals(Collections.singletonList("1984"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_SERVICE_STOP_TIME_FROM.getSlotName()));
+        assertEquals(Collections.singletonList("1985"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_SERVICE_STOP_TIME_TO.getSlotName()));
+        assertEquals(Arrays.asList("('urn:oasis:names:tc:ebxml-regrep:StatusType:Approved')", "('urn:oasis:names:tc:ebxml-regrep:StatusType:Submitted')"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_STATUS.getSlotName()));
+        assertEquals(Arrays.asList("('uuid1')", "('uuid2')"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_UUID.getSlotName()));
+        assertEquals(Arrays.asList("('uniqueId1')", "('uniqueId2')"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_UNIQUE_ID.getSlotName()));
+        assertEquals(Arrays.asList("('code3^^scheme3')", "('code4^^scheme4')"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_PRACTICE_SETTING_CODE.getSlotName()));
+        assertEquals(Arrays.asList("('code5^^scheme5')", "('code6^^scheme6')"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_HEALTHCARE_FACILITY_TYPE_CODE.getSlotName()));
+        List<EbXMLSlot> eventSlots = ebXML.getSlots(QueryParameter.DOC_ENTRY_EVENT_CODE.getSlotName());
+        assertEquals(2, eventSlots.size());
+        assertEquals(Arrays.asList("('code7^^scheme7')", "('code8^^scheme8')"), eventSlots.get(0).getValueList());
+        assertEquals(Collections.singletonList("('code9^^scheme9')"), eventSlots.get(1).getValueList());
+        assertEquals(Arrays.asList("('per''son1')", "('person2')"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_AUTHOR_PERSON.getSlotName()));
+    }
+
+    @Test
+    public void testToEbXMLNull() {
+        transformer.toEbXML(null, ebXML);
+        assertEquals(0, ebXML.getSlots().size());
+    }
+
+    @Test
+    public void testToEbXMLEmpty() {
+        transformer.toEbXML(new FindPrescriptionsForDispenseQuery(), ebXML);
+        assertEquals(0, ebXML.getSlots().size());
+    }
+
+    @Test
+    public void testFromEbXML() {
+        transformer.toEbXML(query, ebXML);
+        FindPrescriptionsForDispenseQuery result = new FindPrescriptionsForDispenseQuery();
+        transformer.fromEbXML(result, ebXML);
+        assertEquals(query, result);
+    }
+
+    @Test
+    public void testFromEbXMLNull() {
+        FindPrescriptionsForDispenseQuery result = new FindPrescriptionsForDispenseQuery();
+        transformer.fromEbXML(result, null);
+        assertEquals(new FindPrescriptionsForDispenseQuery(), result);
+    }
+
+    @Test
+    public void testFromEbXMLEmpty() {
+        FindPrescriptionsForDispenseQuery result = new FindPrescriptionsForDispenseQuery();
+        transformer.fromEbXML(result, ebXML);
+        assertEquals(new FindPrescriptionsForDispenseQuery(), result);
+    }
+}

--- a/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/ebxml30/FindPrescriptionsForValidationQueryTransformerTest.java
+++ b/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/ebxml30/FindPrescriptionsForValidationQueryTransformerTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openehealth.ipf.commons.ihe.xds.core.transform.requests.ebxml30;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openehealth.ipf.commons.ihe.xds.core.ebxml.EbXMLAdhocQueryRequest;
+import org.openehealth.ipf.commons.ihe.xds.core.ebxml.EbXMLSlot;
+import org.openehealth.ipf.commons.ihe.xds.core.ebxml.ebxml30.EbXMLFactory30;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.AssigningAuthority;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.AvailabilityStatus;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Code;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.query.FindPrescriptionsForValidationQuery;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.query.QueryList;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.query.QueryType;
+import org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryParameter;
+import org.openehealth.ipf.commons.ihe.xds.core.transform.requests.query.FindPrescriptionsForValidationQueryTransformer;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link FindPrescriptionsForValidationQueryTransformer}.
+ * @author Quentin Ligier
+ */
+public class FindPrescriptionsForValidationQueryTransformerTest {
+    private FindPrescriptionsForValidationQueryTransformer transformer;
+    private FindPrescriptionsForValidationQuery query;
+    private EbXMLAdhocQueryRequest ebXML;
+
+    @Before
+    public void setUp() {
+        transformer = new FindPrescriptionsForValidationQueryTransformer();
+
+        query = new FindPrescriptionsForValidationQuery();
+        query.setPatientId(new Identifiable("id1", new AssigningAuthority("uni1", "uniType1")));
+        query.setHomeCommunityId("12.21.41");
+        QueryList<Code> confidentialityCodes = new QueryList<>();
+        confidentialityCodes.getOuterList().add(
+                Arrays.asList(new Code("code10", null, "scheme10"), new Code("code11", null, "scheme11")));
+        confidentialityCodes.getOuterList().add(
+                Collections.singletonList(new Code("code12", null, "scheme12")));
+        query.setConfidentialityCodes(confidentialityCodes);
+        query.getCreationTime().setFrom("1980");
+        query.getCreationTime().setTo("1981");
+        query.getServiceStartTime().setFrom("1982");
+        query.getServiceStartTime().setTo("1983");
+        query.getServiceStopTime().setFrom("1984");
+        query.getServiceStopTime().setTo("1985");
+        query.setStatus(Arrays.asList(AvailabilityStatus.APPROVED, AvailabilityStatus.SUBMITTED));
+        query.setUuids(Arrays.asList("uuid1", "uuid2"));
+        query.setUniqueIds(Arrays.asList("uniqueId1", "uniqueId2"));
+        query.setPracticeSettingCodes(Arrays.asList(new Code("code3", null, "scheme3"), new Code("code4", null, "scheme4")));
+        query.setHealthcareFacilityTypeCodes(Arrays.asList(new Code("code5", null, "scheme5"), new Code("code6", null, "scheme6")));
+        QueryList<Code> eventCodes = new QueryList<>();
+        eventCodes.getOuterList().add(
+                Arrays.asList(new Code("code7", null, "scheme7"), new Code("code8", null, "scheme8")));
+        eventCodes.getOuterList().add(
+                Collections.singletonList(new Code("code9", null, "scheme9")));
+        query.setEventCodes(eventCodes);
+        query.setAuthorPersons(Arrays.asList("per'son1", "person2"));
+
+        ebXML = new EbXMLFactory30().createAdhocQueryRequest();
+    }
+
+    @Test
+    public void testToEbXML() {
+        transformer.toEbXML(query, ebXML);
+
+        assertEquals(QueryType.FIND_PRESCRIPTIONS_FOR_VALIDATION.getId(), ebXML.getId());
+        assertEquals("12.21.41", ebXML.getHome());
+        assertEquals(Collections.singletonList("'id1^^^&uni1&uniType1'"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_PATIENT_ID.getSlotName()));
+        List<EbXMLSlot> confidentialitySlots = ebXML.getSlots(QueryParameter.DOC_ENTRY_CONFIDENTIALITY_CODE.getSlotName());
+        assertEquals(2, confidentialitySlots.size());
+        assertEquals(Arrays.asList("('code10^^scheme10')", "('code11^^scheme11')"), confidentialitySlots.get(0).getValueList());
+        assertEquals(Collections.singletonList("('code12^^scheme12')"), confidentialitySlots.get(1).getValueList());
+        assertEquals(Collections.singletonList("1980"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_CREATION_TIME_FROM.getSlotName()));
+        assertEquals(Collections.singletonList("1981"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_CREATION_TIME_TO.getSlotName()));
+        assertEquals(Collections.singletonList("1982"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_SERVICE_START_TIME_FROM.getSlotName()));
+        assertEquals(Collections.singletonList("1983"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_SERVICE_START_TIME_TO.getSlotName()));
+        assertEquals(Collections.singletonList("1984"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_SERVICE_STOP_TIME_FROM.getSlotName()));
+        assertEquals(Collections.singletonList("1985"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_SERVICE_STOP_TIME_TO.getSlotName()));
+        assertEquals(Arrays.asList("('urn:oasis:names:tc:ebxml-regrep:StatusType:Approved')", "('urn:oasis:names:tc:ebxml-regrep:StatusType:Submitted')"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_STATUS.getSlotName()));
+        assertEquals(Arrays.asList("('uuid1')", "('uuid2')"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_UUID.getSlotName()));
+        assertEquals(Arrays.asList("('uniqueId1')", "('uniqueId2')"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_UNIQUE_ID.getSlotName()));
+        assertEquals(Arrays.asList("('code3^^scheme3')", "('code4^^scheme4')"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_PRACTICE_SETTING_CODE.getSlotName()));
+        assertEquals(Arrays.asList("('code5^^scheme5')", "('code6^^scheme6')"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_HEALTHCARE_FACILITY_TYPE_CODE.getSlotName()));
+        List<EbXMLSlot> eventSlots = ebXML.getSlots(QueryParameter.DOC_ENTRY_EVENT_CODE.getSlotName());
+        assertEquals(2, eventSlots.size());
+        assertEquals(Arrays.asList("('code7^^scheme7')", "('code8^^scheme8')"), eventSlots.get(0).getValueList());
+        assertEquals(Collections.singletonList("('code9^^scheme9')"), eventSlots.get(1).getValueList());
+        assertEquals(Arrays.asList("('per''son1')", "('person2')"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_AUTHOR_PERSON.getSlotName()));
+    }
+
+    @Test
+    public void testToEbXMLNull() {
+        transformer.toEbXML(null, ebXML);
+        assertEquals(0, ebXML.getSlots().size());
+    }
+
+    @Test
+    public void testToEbXMLEmpty() {
+        transformer.toEbXML(new FindPrescriptionsForValidationQuery(), ebXML);
+        assertEquals(0, ebXML.getSlots().size());
+    }
+
+    @Test
+    public void testFromEbXML() {
+        transformer.toEbXML(query, ebXML);
+        FindPrescriptionsForValidationQuery result = new FindPrescriptionsForValidationQuery();
+        transformer.fromEbXML(result, ebXML);
+        assertEquals(query, result);
+    }
+
+    @Test
+    public void testFromEbXMLNull() {
+        FindPrescriptionsForValidationQuery result = new FindPrescriptionsForValidationQuery();
+        transformer.fromEbXML(result, null);
+        assertEquals(new FindPrescriptionsForValidationQuery(), result);
+    }
+
+    @Test
+    public void testFromEbXMLEmpty() {
+        FindPrescriptionsForValidationQuery result = new FindPrescriptionsForValidationQuery();
+        transformer.fromEbXML(result, ebXML);
+        assertEquals(new FindPrescriptionsForValidationQuery(), result);
+    }
+}

--- a/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/ebxml30/FindPrescriptionsQueryTransformerTest.java
+++ b/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/ebxml30/FindPrescriptionsQueryTransformerTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openehealth.ipf.commons.ihe.xds.core.transform.requests.ebxml30;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openehealth.ipf.commons.ihe.xds.core.ebxml.EbXMLAdhocQueryRequest;
+import org.openehealth.ipf.commons.ihe.xds.core.ebxml.EbXMLSlot;
+import org.openehealth.ipf.commons.ihe.xds.core.ebxml.ebxml30.EbXMLFactory30;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.AssigningAuthority;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.AvailabilityStatus;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Code;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.query.FindPrescriptionsQuery;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.query.QueryList;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.query.QueryType;
+import org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryParameter;
+import org.openehealth.ipf.commons.ihe.xds.core.transform.requests.query.FindPrescriptionsQueryTransformer;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link FindPrescriptionsQueryTransformer}.
+ * @author Quentin Ligier
+ */
+public class FindPrescriptionsQueryTransformerTest {
+    private FindPrescriptionsQueryTransformer transformer;
+    private FindPrescriptionsQuery query;
+    private EbXMLAdhocQueryRequest ebXML;
+
+    @Before
+    public void setUp() {
+        transformer = new FindPrescriptionsQueryTransformer();
+
+        query = new FindPrescriptionsQuery();
+        query.setPatientId(new Identifiable("id1", new AssigningAuthority("uni1", "uniType1")));
+        query.setHomeCommunityId("12.21.41");
+        QueryList<Code> confidentialityCodes = new QueryList<>();
+        confidentialityCodes.getOuterList().add(
+                Arrays.asList(new Code("code10", null, "scheme10"), new Code("code11", null, "scheme11")));
+        confidentialityCodes.getOuterList().add(
+                Collections.singletonList(new Code("code12", null, "scheme12")));
+        query.setConfidentialityCodes(confidentialityCodes);
+        query.getCreationTime().setFrom("1980");
+        query.getCreationTime().setTo("1981");
+        query.getServiceStartTime().setFrom("1982");
+        query.getServiceStartTime().setTo("1983");
+        query.getServiceStopTime().setFrom("1984");
+        query.getServiceStopTime().setTo("1985");
+        query.setStatus(Arrays.asList(AvailabilityStatus.APPROVED, AvailabilityStatus.SUBMITTED));
+        query.setUuids(Arrays.asList("uuid1", "uuid2"));
+        query.setUniqueIds(Arrays.asList("uniqueId1", "uniqueId2"));
+        query.setPracticeSettingCodes(Arrays.asList(new Code("code3", null, "scheme3"), new Code("code4", null, "scheme4")));
+        query.setHealthcareFacilityTypeCodes(Arrays.asList(new Code("code5", null, "scheme5"), new Code("code6", null, "scheme6")));
+        QueryList<Code> eventCodes = new QueryList<>();
+        eventCodes.getOuterList().add(
+                Arrays.asList(new Code("code7", null, "scheme7"), new Code("code8", null, "scheme8")));
+        eventCodes.getOuterList().add(
+                Collections.singletonList(new Code("code9", null, "scheme9")));
+        query.setEventCodes(eventCodes);
+        query.setAuthorPersons(Arrays.asList("per'son1", "person2"));
+
+        ebXML = new EbXMLFactory30().createAdhocQueryRequest();
+    }
+
+    @Test
+    public void testToEbXML() {
+        transformer.toEbXML(query, ebXML);
+
+        assertEquals(QueryType.FIND_PRESCRIPTIONS.getId(), ebXML.getId());
+        assertEquals("12.21.41", ebXML.getHome());
+        assertEquals(Collections.singletonList("'id1^^^&uni1&uniType1'"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_PATIENT_ID.getSlotName()));
+        List<EbXMLSlot> confidentialitySlots = ebXML.getSlots(QueryParameter.DOC_ENTRY_CONFIDENTIALITY_CODE.getSlotName());
+        assertEquals(2, confidentialitySlots.size());
+        assertEquals(Arrays.asList("('code10^^scheme10')", "('code11^^scheme11')"), confidentialitySlots.get(0).getValueList());
+        assertEquals(Collections.singletonList("('code12^^scheme12')"), confidentialitySlots.get(1).getValueList());
+        assertEquals(Collections.singletonList("1980"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_CREATION_TIME_FROM.getSlotName()));
+        assertEquals(Collections.singletonList("1981"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_CREATION_TIME_TO.getSlotName()));
+        assertEquals(Collections.singletonList("1982"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_SERVICE_START_TIME_FROM.getSlotName()));
+        assertEquals(Collections.singletonList("1983"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_SERVICE_START_TIME_TO.getSlotName()));
+        assertEquals(Collections.singletonList("1984"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_SERVICE_STOP_TIME_FROM.getSlotName()));
+        assertEquals(Collections.singletonList("1985"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_SERVICE_STOP_TIME_TO.getSlotName()));
+        assertEquals(Arrays.asList("('urn:oasis:names:tc:ebxml-regrep:StatusType:Approved')", "('urn:oasis:names:tc:ebxml-regrep:StatusType:Submitted')"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_STATUS.getSlotName()));
+        assertEquals(Arrays.asList("('uuid1')", "('uuid2')"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_UUID.getSlotName()));
+        assertEquals(Arrays.asList("('uniqueId1')", "('uniqueId2')"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_UNIQUE_ID.getSlotName()));
+        assertEquals(Arrays.asList("('code3^^scheme3')", "('code4^^scheme4')"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_PRACTICE_SETTING_CODE.getSlotName()));
+        assertEquals(Arrays.asList("('code5^^scheme5')", "('code6^^scheme6')"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_HEALTHCARE_FACILITY_TYPE_CODE.getSlotName()));
+        List<EbXMLSlot> eventSlots = ebXML.getSlots(QueryParameter.DOC_ENTRY_EVENT_CODE.getSlotName());
+        assertEquals(2, eventSlots.size());
+        assertEquals(Arrays.asList("('code7^^scheme7')", "('code8^^scheme8')"), eventSlots.get(0).getValueList());
+        assertEquals(Collections.singletonList("('code9^^scheme9')"), eventSlots.get(1).getValueList());
+        assertEquals(Arrays.asList("('per''son1')", "('person2')"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_AUTHOR_PERSON.getSlotName()));
+    }
+
+    @Test
+    public void testToEbXMLNull() {
+        transformer.toEbXML(null, ebXML);
+        assertEquals(0, ebXML.getSlots().size());
+    }
+
+    @Test
+    public void testToEbXMLEmpty() {
+        transformer.toEbXML(new FindPrescriptionsQuery(), ebXML);
+        assertEquals(0, ebXML.getSlots().size());
+    }
+
+    @Test
+    public void testFromEbXML() {
+        transformer.toEbXML(query, ebXML);
+        FindPrescriptionsQuery result = new FindPrescriptionsQuery();
+        transformer.fromEbXML(result, ebXML);
+        assertEquals(query, result);
+    }
+
+    @Test
+    public void testFromEbXMLNull() {
+        FindPrescriptionsQuery result = new FindPrescriptionsQuery();
+        transformer.fromEbXML(result, null);
+        assertEquals(new FindPrescriptionsQuery(), result);
+    }
+
+    @Test
+    public void testFromEbXMLEmpty() {
+        FindPrescriptionsQuery result = new FindPrescriptionsQuery();
+        transformer.fromEbXML(result, ebXML);
+        assertEquals(new FindPrescriptionsQuery(), result);
+    }
+}

--- a/platform-camel/ihe/src/site/markdown/index.md
+++ b/platform-camel/ihe/src/site/markdown/index.md
@@ -201,6 +201,7 @@ required dependencies, usage and parameters.
 | [ITI-83]     | PIXm          | Patient Identifier Cross-reference for Mobile | `pixm-iti83`   | REST/HTTP(S)  | FHIR
 | [ITI-86]     | RMD           | Remove Documents                     | `rmd-iti86`             | SOAP/HTTP(S)  | ebXML
 | [ITI-92]     | RMU           | Restricted Update Document Set       | `rmu-iti92`             | SOAP/HTTP(S)  | ebXML
+| [PHARM-1]    | XDS           | Query Pharmacy Documents             | `xds-pharm1`            | SOAP/HTTP(S)  | ebXML
 | [RAD-69]     | XDS-I, XCA-I  | Retrieve Imaging Document Set        | `xdsi-rad69`            | SOAP/HTTP(S)  | ebXML
 | [RAD-75]     | XCA-I         | Cross-Gateway Retrieve Imaging Document Set | `xcai-rad75`     | SOAP/HTTP(S)  | ebXML
 | [PCC-1]      | QED           | Query for Existing Data              | `qed-pcc1`              | SOAP/HTTP(S)  | HL7v3
@@ -250,6 +251,7 @@ required dependencies, usage and parameters.
 [ITI-83]: ../ipf-platform-camel-ihe-fhir-stu3-pixpdq/iti83.html
 [ITI-86]: ../ipf-platform-camel-ihe-xds/iti86.html
 [ITI-92]: ../ipf-platform-camel-ihe-xds/iti92.html
+[PHARM-1]: ../ipf-platform-camel-ihe-xds/pharm1.html
 [RAD-69]: ../ipf-platform-camel-ihe-xds/rad69.html
 [RAD-75]: ../ipf-platform-camel-ihe-xds/rad75.html
 [PCC-1]: ../ipf-platform-camel-ihe-hl7v3/pcc1.html

--- a/platform-camel/ihe/xds/META-INF/services/org/apache/camel/component/xds-pharm1
+++ b/platform-camel/ihe/xds/META-INF/services/org/apache/camel/component/xds-pharm1
@@ -1,0 +1,12 @@
+#    Copyright 2009 the original author or authors. Licensed under the Apache
+#    License, Version 2.0 (the "License"); you may not use this file except
+#    in compliance with the License. You may obtain a copy of the License at
+#    http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable
+#    law or agreed to in writing, software distributed under the License is
+#    distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#    KIND, either express or implied. See the License for the specific
+#    language governing permissions and limitations under the License.
+
+# Camel registration for the xds-pharm1 component
+
+class=org.openehealth.ipf.platform.camel.ihe.xds.pharm1.Pharm1Component

--- a/platform-camel/ihe/xds/src/main/java/org/openehealth/ipf/platform/camel/ihe/xds/XdsCamelValidators.java
+++ b/platform-camel/ihe/xds/src/main/java/org/openehealth/ipf/platform/camel/ihe/xds/XdsCamelValidators.java
@@ -565,4 +565,40 @@ public abstract class XdsCamelValidators {
     public static Processor rad75ResponseValidator() {
         return RAD_75_RESPONSE_VALIDATOR;
     }
+
+    private static final Processor PHARM_1_REQUEST_VALIDATOR = exchange -> {
+        if (! validationEnabled(exchange)) {
+            return;
+        }
+        EbXMLAdhocQueryRequest30 message =
+                new EbXMLAdhocQueryRequest30(exchange.getIn().getBody(AdhocQueryRequest.class));
+        new AdhocQueryRequestValidator().validate(message, PHARM_1);
+    };
+
+    private static final Processor PHARM_1_RESPONSE_VALIDATOR = exchange -> {
+        if (! validationEnabled(exchange)) {
+            return;
+        }
+        EbXMLQueryResponse30 message =
+                new EbXMLQueryResponse30(exchange.getIn().getBody(AdhocQueryResponse.class));
+        new QueryResponseValidator().validate(message, PHARM_1);
+    };
+
+    /**
+     * Returns a validating processor for PHARM-1 request messages.
+     *
+     * @return PHARM_1_REQUEST_VALIDATOR
+     */
+    public static Processor pharm1RequestValidator() {
+        return PHARM_1_REQUEST_VALIDATOR;
+    }
+
+    /**
+     * Returns a validating processor for PHARM-1 response messages.
+     *
+     * @return PHARM_1_RESPONSE_VALIDATOR
+     */
+    public static Processor pharm1ResponseValidator() {
+        return PHARM_1_RESPONSE_VALIDATOR;
+    }
 }

--- a/platform-camel/ihe/xds/src/main/java/org/openehealth/ipf/platform/camel/ihe/xds/core/converters/XdsRenderingUtils.java
+++ b/platform-camel/ihe/xds/src/main/java/org/openehealth/ipf/platform/camel/ihe/xds/core/converters/XdsRenderingUtils.java
@@ -60,7 +60,7 @@ public abstract class XdsRenderingUtils {
 
         /* --------- REQUESTS --------- */
 
-        // ITI-18, 38, 51, 63
+        // ITI-18, 38, 51, 63, PHARM-1
         TYPES_CORRESPONDENCE.put(QueryRegistry.class, AdhocQueryRequest.class);
 
         // ITI-41
@@ -83,7 +83,7 @@ public abstract class XdsRenderingUtils {
 
         /* --------- RESPONSES --------- */
 
-        // ITI-18, 38, 51, 63
+        // ITI-18, 38, 51, 63, PHARM-1
         TYPES_CORRESPONDENCE.put(QueryResponse.class, AdhocQueryResponse.class);
 
         // ITI-41, 42, 57, 61, 62, 86

--- a/platform-camel/ihe/xds/src/main/java/org/openehealth/ipf/platform/camel/ihe/xds/pharm1/Pharm1Component.java
+++ b/platform-camel/ihe/xds/src/main/java/org/openehealth/ipf/platform/camel/ihe/xds/pharm1/Pharm1Component.java
@@ -1,0 +1,30 @@
+package org.openehealth.ipf.platform.camel.ihe.xds.pharm1;
+
+import java.util.Map;
+import org.apache.camel.Endpoint;
+import org.openehealth.ipf.commons.ihe.ws.JaxWsClientFactory;
+import org.openehealth.ipf.commons.ihe.ws.WsTransactionConfiguration;
+import org.openehealth.ipf.commons.ihe.xds.XDS;
+import org.openehealth.ipf.commons.ihe.xds.core.audit.XdsQueryAuditDataset;
+import org.openehealth.ipf.commons.ihe.xds.core.stub.ebrs30.query.AdhocQueryRequest;
+import org.openehealth.ipf.commons.ihe.xds.core.stub.ebrs30.query.AdhocQueryResponse;
+import org.openehealth.ipf.platform.camel.ihe.ws.AbstractWsEndpoint;
+import org.openehealth.ipf.platform.camel.ihe.ws.AbstractWsProducer;
+import org.openehealth.ipf.platform.camel.ihe.ws.SimpleWsProducer;
+import org.openehealth.ipf.platform.camel.ihe.xds.XdsComponent;
+import org.openehealth.ipf.platform.camel.ihe.xds.XdsEndpoint;
+import org.openehealth.ipf.platform.camel.ihe.xds.iti18.Iti18Service;
+
+public class Pharm1Component extends XdsComponent<XdsQueryAuditDataset> {
+    public Pharm1Component() {
+        super(XDS.Interactions.ITI_18);
+    }
+
+    protected Endpoint createEndpoint(String uri, String remaining, Map<String, Object> parameters) {
+        return new XdsEndpoint<XdsQueryAuditDataset>(uri, remaining, this, parameters, Iti18Service.class) {
+            public AbstractWsProducer<XdsQueryAuditDataset, WsTransactionConfiguration<XdsQueryAuditDataset>, ?, ?> getProducer(AbstractWsEndpoint<XdsQueryAuditDataset, WsTransactionConfiguration<XdsQueryAuditDataset>> endpoint, JaxWsClientFactory<XdsQueryAuditDataset> clientFactory) {
+                return new SimpleWsProducer(endpoint, clientFactory, AdhocQueryRequest.class, AdhocQueryResponse.class);
+            }
+        };
+    }
+}

--- a/platform-camel/ihe/xds/src/main/java/org/openehealth/ipf/platform/camel/ihe/xds/pharm1/Pharm1Component.java
+++ b/platform-camel/ihe/xds/src/main/java/org/openehealth/ipf/platform/camel/ihe/xds/pharm1/Pharm1Component.java
@@ -1,10 +1,8 @@
 package org.openehealth.ipf.platform.camel.ihe.xds.pharm1;
 
-import java.util.Map;
 import org.apache.camel.Endpoint;
 import org.openehealth.ipf.commons.ihe.ws.JaxWsClientFactory;
 import org.openehealth.ipf.commons.ihe.ws.WsTransactionConfiguration;
-import org.openehealth.ipf.commons.ihe.xds.XDS;
 import org.openehealth.ipf.commons.ihe.xds.core.audit.XdsQueryAuditDataset;
 import org.openehealth.ipf.commons.ihe.xds.core.stub.ebrs30.query.AdhocQueryRequest;
 import org.openehealth.ipf.commons.ihe.xds.core.stub.ebrs30.query.AdhocQueryResponse;
@@ -13,8 +11,10 @@ import org.openehealth.ipf.platform.camel.ihe.ws.AbstractWsProducer;
 import org.openehealth.ipf.platform.camel.ihe.ws.SimpleWsProducer;
 import org.openehealth.ipf.platform.camel.ihe.xds.XdsComponent;
 import org.openehealth.ipf.platform.camel.ihe.xds.XdsEndpoint;
-import org.openehealth.ipf.platform.camel.ihe.xds.iti18.Iti18Service;
 
+import java.util.Map;
+
+import static org.openehealth.ipf.commons.ihe.xds.XDS.Interactions.PHARM_1;
 
 /**
  * The Camel component for the IHE PHARM-1 transaction.
@@ -22,12 +22,12 @@ import org.openehealth.ipf.platform.camel.ihe.xds.iti18.Iti18Service;
 public class Pharm1Component extends XdsComponent<XdsQueryAuditDataset> {
 
     public Pharm1Component() {
-        super(XDS.Interactions.PHARM_1);
+        super(PHARM_1);
     }
 
     @Override
     protected Endpoint createEndpoint(String uri, String remaining, Map<String, Object> parameters) {
-        return new XdsEndpoint<XdsQueryAuditDataset>(uri, remaining, this, parameters, Iti18Service.class) {
+        return new XdsEndpoint<XdsQueryAuditDataset>(uri, remaining, this, parameters, Pharm1Service.class) {
             @Override
             public AbstractWsProducer<XdsQueryAuditDataset, WsTransactionConfiguration<XdsQueryAuditDataset>, ?, ?> getProducer(AbstractWsEndpoint<XdsQueryAuditDataset, WsTransactionConfiguration<XdsQueryAuditDataset>> endpoint, JaxWsClientFactory<XdsQueryAuditDataset> clientFactory) {
                 return new SimpleWsProducer(endpoint, clientFactory, AdhocQueryRequest.class, AdhocQueryResponse.class);

--- a/platform-camel/ihe/xds/src/main/java/org/openehealth/ipf/platform/camel/ihe/xds/pharm1/Pharm1Component.java
+++ b/platform-camel/ihe/xds/src/main/java/org/openehealth/ipf/platform/camel/ihe/xds/pharm1/Pharm1Component.java
@@ -17,7 +17,7 @@ import org.openehealth.ipf.platform.camel.ihe.xds.iti18.Iti18Service;
 
 
 /**
- * The Camel component for the PHARM-1 transaction.
+ * The Camel component for the IHE PHARM-1 transaction.
  */
 public class Pharm1Component extends XdsComponent<XdsQueryAuditDataset> {
 

--- a/platform-camel/ihe/xds/src/main/java/org/openehealth/ipf/platform/camel/ihe/xds/pharm1/Pharm1Component.java
+++ b/platform-camel/ihe/xds/src/main/java/org/openehealth/ipf/platform/camel/ihe/xds/pharm1/Pharm1Component.java
@@ -15,13 +15,20 @@ import org.openehealth.ipf.platform.camel.ihe.xds.XdsComponent;
 import org.openehealth.ipf.platform.camel.ihe.xds.XdsEndpoint;
 import org.openehealth.ipf.platform.camel.ihe.xds.iti18.Iti18Service;
 
+
+/**
+ * The Camel component for the PHARM-1 transaction.
+ */
 public class Pharm1Component extends XdsComponent<XdsQueryAuditDataset> {
+
     public Pharm1Component() {
-        super(XDS.Interactions.ITI_18);
+        super(XDS.Interactions.PHARM_1);
     }
 
+    @Override
     protected Endpoint createEndpoint(String uri, String remaining, Map<String, Object> parameters) {
         return new XdsEndpoint<XdsQueryAuditDataset>(uri, remaining, this, parameters, Iti18Service.class) {
+            @Override
             public AbstractWsProducer<XdsQueryAuditDataset, WsTransactionConfiguration<XdsQueryAuditDataset>, ?, ?> getProducer(AbstractWsEndpoint<XdsQueryAuditDataset, WsTransactionConfiguration<XdsQueryAuditDataset>> endpoint, JaxWsClientFactory<XdsQueryAuditDataset> clientFactory) {
                 return new SimpleWsProducer(endpoint, clientFactory, AdhocQueryRequest.class, AdhocQueryResponse.class);
             }

--- a/platform-camel/ihe/xds/src/main/java/org/openehealth/ipf/platform/camel/ihe/xds/pharm1/Pharm1Component.java
+++ b/platform-camel/ihe/xds/src/main/java/org/openehealth/ipf/platform/camel/ihe/xds/pharm1/Pharm1Component.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openehealth.ipf.platform.camel.ihe.xds.pharm1;
 
 import org.apache.camel.Endpoint;

--- a/platform-camel/ihe/xds/src/main/java/org/openehealth/ipf/platform/camel/ihe/xds/pharm1/Pharm1Service.java
+++ b/platform-camel/ihe/xds/src/main/java/org/openehealth/ipf/platform/camel/ihe/xds/pharm1/Pharm1Service.java
@@ -22,7 +22,7 @@ import org.openehealth.ipf.commons.ihe.xds.pharm1.Pharm1PortType;
 import org.openehealth.ipf.platform.camel.ihe.xds.XdsAdhocQueryService;
 
 /**
- * Service implementation for the IHE PHARM-1 transaction (Registry Stored Query).
+ * Service implementation for the IHE PHARM-1 transaction (Query Pharmacy Documents).
  * <p>
  * This implementation delegates to a Camel consumer by creating an exchange.
  *

--- a/platform-camel/ihe/xds/src/main/java/org/openehealth/ipf/platform/camel/ihe/xds/pharm1/Pharm1Service.java
+++ b/platform-camel/ihe/xds/src/main/java/org/openehealth/ipf/platform/camel/ihe/xds/pharm1/Pharm1Service.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.openehealth.ipf.platform.camel.ihe.xds.pharm1;
 
 import org.openehealth.ipf.commons.ihe.xds.core.stub.ebrs30.query.AdhocQueryRequest;
@@ -5,12 +21,20 @@ import org.openehealth.ipf.commons.ihe.xds.core.stub.ebrs30.query.AdhocQueryResp
 import org.openehealth.ipf.commons.ihe.xds.pharm1.Pharm1PortType;
 import org.openehealth.ipf.platform.camel.ihe.xds.XdsAdhocQueryService;
 
+/**
+ * Service implementation for the IHE PHARM-1 transaction (Registry Stored Query).
+ * <p>
+ * This implementation delegates to a Camel consumer by creating an exchange.
+ *
+ * @author Quentin Ligier
+ */
 public class Pharm1Service extends XdsAdhocQueryService implements Pharm1PortType {
+
     public Pharm1Service() {
         super((String)null);
     }
 
-    // TODO
+    @Override
     public AdhocQueryResponse communityPharmacyManagerQueryPharmacyDocuments(AdhocQueryRequest body) {
         return this.processRequest(body);
     }

--- a/platform-camel/ihe/xds/src/main/java/org/openehealth/ipf/platform/camel/ihe/xds/pharm1/Pharm1Service.java
+++ b/platform-camel/ihe/xds/src/main/java/org/openehealth/ipf/platform/camel/ihe/xds/pharm1/Pharm1Service.java
@@ -1,0 +1,17 @@
+package org.openehealth.ipf.platform.camel.ihe.xds.pharm1;
+
+import org.openehealth.ipf.commons.ihe.xds.core.stub.ebrs30.query.AdhocQueryRequest;
+import org.openehealth.ipf.commons.ihe.xds.core.stub.ebrs30.query.AdhocQueryResponse;
+import org.openehealth.ipf.commons.ihe.xds.pharm1.Pharm1PortType;
+import org.openehealth.ipf.platform.camel.ihe.xds.XdsAdhocQueryService;
+
+public class Pharm1Service extends XdsAdhocQueryService implements Pharm1PortType {
+    public Pharm1Service() {
+        super((String)null);
+    }
+
+    // TODO
+    public AdhocQueryResponse communityPharmacyManagerQueryPharmacyDocuments(AdhocQueryRequest body) {
+        return this.processRequest(body);
+    }
+}

--- a/platform-camel/ihe/xds/src/site/markdown/pharm1.md
+++ b/platform-camel/ihe/xds/src/site/markdown/pharm1.md
@@ -1,0 +1,122 @@
+
+## `xds-pharm1` component
+
+The xds-pharm1 component provides interfaces for actors of the *Query Pharmacy Documents* IHE transaction (PHARM-1),
+which is described in the [IHE Pharmacy Technical Framework Supplement, Community Medication Prescription and Dispense, Section 3.1](https://www.ihe.net/uploadedFiles/Documents/Pharmacy/IHE_Pharmacy_Suppl_CMPD.pdf).
+It is very similar to the Registry Stored Query transaction ([ITI-18]).
+
+### Actors
+
+The transaction defines the following actors:
+
+![ITI-18 actors](images/iti18.png)
+
+Producer side corresponds to the *Document Consumer* actor.
+Consumer side corresponds to the *Document Registry* actor.
+
+### Dependencies
+
+In a Maven-based environment, the following dependency must be registered in `pom.xml`:
+
+```xml
+    <dependency>
+        <groupId>org.openehealth.ipf.platform-camel</groupId>
+        <artifactId>ipf-platform-camel-ihe-xds</artifactId>
+        <version>${ipf-version}</version>
+    </dependency>
+```
+
+### Endpoint URI Format
+
+#### Producer
+
+The endpoint URI format of `xds-pharm1` component producers is:
+
+```
+xds-pharm1://hostname:port/path/to/service[?parameters]
+```
+
+where *hostname* is either an IP address or a domain name, *port* is a port number, and *path/to/service*
+represents additional path elements of the remote service.
+URI parameters are optional and control special features as described in the corresponding section below.
+
+#### Consumer
+
+The endpoint URI format of `xds-pharm1` component consumers is:
+
+```
+xds-pharm1:serviceName[?parameters]
+```
+
+The resulting URL of the exposed IHE Web Service endpoint depends on both the configuration of the [deployment container]
+and the serviceName parameter provided in the Camel endpoint URI.
+
+For example, when a Tomcat container on the host `eHealth.server.org` is configured in the following way:
+
+```
+port = 8888
+contextPath = /IHE
+servletPath = /xds/*
+```
+
+and serviceName equals to `pharm1Service`, then the xds-iti18 consumer will be available for external clients under the URL
+`http://eHealth.server.org:8888/IHE/xds/pharm1Service`
+
+Additional URI parameters are optional and control special features as described in the corresponding section below.
+
+
+### Example
+
+This is an example on how to use the component on the consumer side:
+
+```java
+    from("xds-pharm1:pharm1Service?audit=true")
+      .process(myProcessor)
+      // process the incoming request and create a response
+```
+
+
+### Basic Common Component Features
+
+* [ATNA auditing]
+* [Message validation]
+
+### Basic Web Service Component Features
+
+* [Secure transport]
+* [File-Based payload logging]
+
+### Basic XDS Component Features
+
+* [Message types]
+
+### Advanced Web Service Component Features
+
+* [Handling Protocol Headers]
+* [Deploying custom CXF interceptors]
+* [Handling automatically rejected messages]
+* [Using CXF features]
+
+### Advanced XDS Component Features
+
+* [Handling extra query parameters and extra metadata elements]
+
+
+[ATNA auditing]: ../ipf-platform-camel-ihe/atna.html
+[Message validation]: ../ipf-platform-camel-ihe/messageValidation.html
+
+[deployment container]: ../ipf-platform-camel-ihe-ws/deployment.html
+[Secure Transport]: ../ipf-platform-camel-ihe-ws/secureTransport.html
+[File-Based payload logging]: ../ipf-platform-camel-ihe-ws/payloadLogging.html
+
+[Message types]: messageTypes.html
+[Handling extra query parameters and extra metadata elements]: handlingExtra.html
+
+[Handling Protocol Headers]: ../ipf-platform-camel-ihe-ws/protocolHeaders.html
+[Deploying custom CXF interceptors]: ../ipf-platform-camel-ihe-ws/customInterceptors.html
+[Handling automatically rejected messages]: ../ipf-platform-camel-ihe-ws/handlingRejected.html
+[Using CXF features]: ../ipf-platform-camel-ihe-ws/cxfFeatures.html
+
+
+
+

--- a/platform-camel/ihe/xds/src/test/groovy/org/openehealth/ipf/platform/camel/ihe/xds/pharm1/Pharm1TestRouteBuilder.groovy
+++ b/platform-camel/ihe/xds/src/test/groovy/org/openehealth/ipf/platform/camel/ihe/xds/pharm1/Pharm1TestRouteBuilder.groovy
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openehealth.ipf.platform.camel.ihe.xds.pharm1
+
+import org.apache.camel.spring.SpringRouteBuilder
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.ObjectReference
+import org.openehealth.ipf.commons.ihe.xds.core.requests.QueryRegistry
+import org.openehealth.ipf.commons.ihe.xds.core.requests.query.FindDispensesQuery
+import org.openehealth.ipf.commons.ihe.xds.core.requests.query.FindMedicationListQuery
+import org.openehealth.ipf.commons.ihe.xds.core.responses.QueryResponse
+
+import static org.openehealth.ipf.commons.ihe.xds.core.responses.Status.FAILURE
+import static org.openehealth.ipf.commons.ihe.xds.core.responses.Status.SUCCESS
+import static org.openehealth.ipf.platform.camel.core.util.Exchanges.resultMessage
+import static org.openehealth.ipf.platform.camel.ihe.xds.XdsCamelValidators.*
+
+/**
+ * Test routes for PHARM-1.
+ * @author Jens Riemschneider
+ * @author Quentin Ligier
+ */
+class Pharm1TestRouteBuilder extends SpringRouteBuilder {
+    void configure() throws Exception {
+        from('xds-pharm1:xds-pharm1-service1')
+            .id('service1route')
+            .process(pharm1RequestValidator())
+            .process { checkValue(it, 'service 1') }
+            .process(pharm1ResponseValidator())
+
+        from('xds-pharm1:xds-pharm1-service2')
+            .process { checkValue(it, 'service 2') }
+
+        // three endpoints intended for SOAP version check
+        from('xds-pharm1:xds-pharm1-service21')
+            .process { checkValue(it, 'implicit SOAP 1.2') }
+        from('xds-pharm1:xds-pharm1-service22')
+            .process { checkValue(it, 'SOAP 1.2') }
+        from('xds-pharm1:xds-pharm1-service23')
+            .process { checkValue(it, 'SOAP 1.1') }
+
+
+        from('xds-pharm1:myPharm1Service?features=#loggingFeature')
+            .convertBodyTo(QueryRegistry.class)
+            .choice()
+                // Return an object reference for a find dispenses query or a find medication list query
+                .when { it.in.body.query instanceof FindDispensesQuery }
+                    .process {
+                        def response = new QueryResponse(SUCCESS)
+                        response.references.add(new ObjectReference('document01'))
+                        resultMessage(it).body = response
+                    }
+                .when { it.in.body.query instanceof FindMedicationListQuery }
+                    .process {
+                        def response = new QueryResponse(SUCCESS)
+                        response.references.add(new ObjectReference('document01'))
+                        resultMessage(it).body = response
+                    }
+                // Any other query else is a failure
+            .otherwise()
+                .process { resultMessage(it).body = new QueryResponse(FAILURE) }
+
+        from('xds-pharm1:featuresTest?features=#policyFeature,#gzipFeature')
+                .process(pharm1RequestValidator())
+                .process { checkValue(it, 'service 1') }
+                .process(pharm1ResponseValidator())
+
+    }
+
+    def checkValue(exchange, expected) {
+        def query = exchange.in.getBody(QueryRegistry.class).query
+        def value = query.authorPersons[0]
+        def response = new QueryResponse(expected == value ? SUCCESS : FAILURE)
+        resultMessage(exchange).body = response
+    }
+}

--- a/platform-camel/ihe/xds/src/test/groovy/org/openehealth/ipf/platform/camel/ihe/xds/pharm1/TestPharm1.groovy
+++ b/platform-camel/ihe/xds/src/test/groovy/org/openehealth/ipf/platform/camel/ihe/xds/pharm1/TestPharm1.groovy
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openehealth.ipf.platform.camel.ihe.xds.pharm1
+
+import org.apache.camel.RuntimeCamelException
+import org.apache.cxf.transport.servlet.CXFServlet
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Test
+import org.openehealth.ipf.commons.audit.codes.EventActionCode
+import org.openehealth.ipf.commons.audit.codes.EventOutcomeIndicator
+import org.openehealth.ipf.commons.audit.model.AuditMessage
+import org.openehealth.ipf.commons.ihe.xds.core.SampleData
+import org.openehealth.ipf.commons.ihe.xds.core.requests.QueryRegistry
+import org.openehealth.ipf.commons.ihe.xds.core.requests.query.FindDispensesQuery
+import org.openehealth.ipf.commons.ihe.xds.core.requests.query.QueryList
+import org.openehealth.ipf.commons.ihe.xds.core.requests.query.QueryType
+import org.openehealth.ipf.commons.ihe.xds.core.responses.QueryResponse
+import org.openehealth.ipf.platform.camel.ihe.xds.XdsStandardTestContainer
+
+import static org.junit.Assert.fail
+import static org.openehealth.ipf.commons.ihe.xds.core.responses.Status.FAILURE
+import static org.openehealth.ipf.commons.ihe.xds.core.responses.Status.SUCCESS
+
+/**
+ * Tests the PHARM-1 component with the webservice and the client defined within the URI.
+ * @author Jens Riemschneider
+ * @author Quentin Ligier
+ */
+class TestPharm1 extends XdsStandardTestContainer {
+
+    def static CONTEXT_DESCRIPTOR = 'pharm-1.xml'
+
+    def SERVICE1 = "xds-pharm1://localhost:${port}/xds-pharm1-service1"
+    def SERVICE2 = "xds-pharm1://localhost:${port}/xds-pharm1-service2"
+    def SAMPLE_SERVICE = "xds-pharm1://localhost:${port}/myPharm1Service?features=#loggingFeature"
+
+    def SERVICE2_ADDR = "http://localhost:${port}/xds-pharm1-service2"
+
+    QueryRegistry request
+    FindDispensesQuery query
+
+    static void main(args) {
+        startServer(new CXFServlet(), CONTEXT_DESCRIPTOR, false, DEMO_APP_PORT)
+    }
+
+    @BeforeClass
+    static void classSetUp() {
+        startServer(new CXFServlet(), CONTEXT_DESCRIPTOR)
+    }
+
+    @Before
+    void setUp() {
+        request = SampleData.createFindDispensesQuery()
+        query = request.query
+
+        QueryList<String> params1 = new QueryList<>()
+        params1.outerList << ['a', 'b', 'c']
+        params1.outerList << ['d', 'e', 'f']
+        params1.outerList << ['h', 'i', 'j']
+
+        QueryList<String> params2 = new QueryList<>()
+        params2.outerList << ['12', '34']
+        params2.outerList << ['56', '78', '90']
+
+        query.extraParameters['$urn:oehf:test1'] = params1
+        query.extraParameters['$urn:oehf:test2'] = params2
+    }
+
+    @Test
+    void testComponentCanBeRestarted() {
+        camelContext.stopRoute('service1route')
+        try {
+            sendIt(SERVICE1, 'service 1').status
+            fail('Expected exception: ' + RuntimeCamelException.class)
+        }
+        catch (Exception ignored) {
+        }
+
+        camelContext.startRoute('service1route')
+        assert SUCCESS == sendIt(SERVICE1, 'service 1').status
+    }
+
+    @Test
+    void testPharm1() {
+        assert SUCCESS == sendIt(SERVICE1, 'service 1').status
+        assert SUCCESS == sendIt(SERVICE2, 'service 2').status
+        assert auditSender.messages.size() == 4
+        checkAudit(EventOutcomeIndicator.Success)
+    }
+
+    @Test
+    void testPharm1FailureAudit() {
+        assert FAILURE == sendIt(SERVICE2, 'falsch').status
+        assert auditSender.messages.size() == 2
+        checkAudit(EventOutcomeIndicator.SeriousFailure)
+    }
+
+    def checkAudit(EventOutcomeIndicator outcome) {
+        List<AuditMessage> messages = getAudit(EventActionCode.Execute, SERVICE2_ADDR)
+        assert messages.size() == 2
+        messages.each { message ->
+            assert message.activeParticipants.size() == 2
+            assert message.participantObjectIdentifications.size() == 2
+
+            checkEvent(message.eventIdentification, '110112', 'PHARM-1', EventActionCode.Execute, outcome)
+            checkSource(message.activeParticipants[0], true)
+            checkDestination(message.activeParticipants[1], SERVICE2_ADDR, false)
+            checkPatient(message.participantObjectIdentifications[0])
+            checkQuery(message.participantObjectIdentifications[1], 'PHARM-1', QueryType.FIND_DISPENSES.getId(), QueryType.FIND_DISPENSES.getId())
+        }
+    }
+
+    @Test
+    void testSample() {
+        def response = send(SAMPLE_SERVICE, SampleData.createFindDispensesQuery(), QueryResponse.class)
+        assert SUCCESS == response.status
+        assert 1 == response.references.size()
+        assert 'document01' == response.references[0].id
+
+        response = send(SAMPLE_SERVICE, SampleData.createFindMedicationListQuery(), QueryResponse.class)
+        assert SUCCESS == response.status
+        assert 1 == response.references.size()
+        assert 'document01' == response.references[0].id
+
+        response = send(SAMPLE_SERVICE, SampleData.createFindPrescriptionsQuery(), QueryResponse.class)
+        assert FAILURE == response.status
+
+        assert auditSender.messages.size() == 6
+        auditSender.messages.each { message ->
+            assert message.activeParticipants.size() == 2
+            assert message.participantObjectIdentifications.size() == 2
+        }
+
+        AuditMessage message = auditSender.messages[0] // FindDispensesQuery, Querying actor audit message
+        checkEvent(message.eventIdentification, '110112', 'PHARM-1', EventActionCode.Execute, EventOutcomeIndicator.Success)
+        checkSource(message.activeParticipants[0], true)
+        checkDestination(message.activeParticipants[1], "http://localhost:${port}/myPharm1Service", false)
+        checkPatient(message.participantObjectIdentifications[0])
+        checkQuery(message.participantObjectIdentifications[1], 'PHARM-1', QueryType.FIND_DISPENSES.getId(), QueryType.FIND_DISPENSES.getId())
+
+        message = auditSender.messages[1] // FindDispensesQuery, Community Pharmacy Manager audit message
+        checkEvent(message.eventIdentification, '110112', 'PHARM-1', EventActionCode.Execute, EventOutcomeIndicator.Success)
+        checkSource(message.activeParticipants[0], true)
+        checkDestination(message.activeParticipants[1], "http://localhost:${port}/myPharm1Service", false)
+        checkPatient(message.participantObjectIdentifications[0])
+        checkQuery(message.participantObjectIdentifications[1], 'PHARM-1', QueryType.FIND_DISPENSES.getId(), QueryType.FIND_DISPENSES.getId())
+
+        message = auditSender.messages[2] // FindMedicationListQuery, Querying actor audit message
+        checkEvent(message.eventIdentification, '110112', 'PHARM-1', EventActionCode.Execute, EventOutcomeIndicator.Success)
+        checkSource(message.activeParticipants[0], true)
+        checkDestination(message.activeParticipants[1], "http://localhost:${port}/myPharm1Service", false)
+        checkPatient(message.participantObjectIdentifications[0])
+        checkQuery(message.participantObjectIdentifications[1], 'PHARM-1', QueryType.FIND_MEDICATION_LIST.getId(), QueryType.FIND_MEDICATION_LIST.getId())
+
+        message = auditSender.messages[3] // FindMedicationListQuery, Community Pharmacy Manager audit message
+        checkEvent(message.eventIdentification, '110112', 'PHARM-1', EventActionCode.Execute, EventOutcomeIndicator.Success)
+        checkSource(message.activeParticipants[0], true)
+        checkDestination(message.activeParticipants[1], "http://localhost:${port}/myPharm1Service", false)
+        checkPatient(message.participantObjectIdentifications[0])
+        checkQuery(message.participantObjectIdentifications[1], 'PHARM-1', QueryType.FIND_MEDICATION_LIST.getId(), QueryType.FIND_MEDICATION_LIST.getId())
+
+        message = auditSender.messages[4] // FindPrescriptionsQuery, Querying actor audit message
+        checkEvent(message.eventIdentification, '110112', 'PHARM-1', EventActionCode.Execute, EventOutcomeIndicator.SeriousFailure)
+        checkSource(message.activeParticipants[0], true)
+        checkDestination(message.activeParticipants[1], "http://localhost:${port}/myPharm1Service", false)
+        checkPatient(message.participantObjectIdentifications[0])
+        checkQuery(message.participantObjectIdentifications[1], 'PHARM-1', QueryType.FIND_PRESCRIPTIONS.getId(), QueryType.FIND_PRESCRIPTIONS.getId())
+
+        message = auditSender.messages[5] // FindPrescriptionsQuery, Community Pharmacy Manager audit message
+        checkEvent(message.eventIdentification, '110112', 'PHARM-1', EventActionCode.Execute, EventOutcomeIndicator.SeriousFailure)
+        checkSource(message.activeParticipants[0], true)
+        checkDestination(message.activeParticipants[1], "http://localhost:${port}/myPharm1Service", false)
+        checkPatient(message.participantObjectIdentifications[0])
+        checkQuery(message.participantObjectIdentifications[1], 'PHARM-1', QueryType.FIND_PRESCRIPTIONS.getId(), QueryType.FIND_PRESCRIPTIONS.getId())
+
+        [4, 5].each { i ->
+            boolean found = false
+            message = auditSender.messages[i]
+            for (detail in message.participantObjectIdentifications[1].participantObjectDetails) {
+                if ((detail.type == 'urn:ihe:iti:xca:2010:homeCommunityId') && detail.value) {
+                    found = true
+                }
+            }
+            assert found
+        }
+    }
+
+    def sendIt(endpoint, value) {
+        query.authorPersons = [value]
+        send(endpoint, request, QueryResponse.class)
+    }
+}

--- a/platform-camel/ihe/xds/src/test/java/org/openehealth/ipf/platform/camel/ihe/xds/dispatch/DispatchAuditStrategy.java
+++ b/platform-camel/ihe/xds/src/test/java/org/openehealth/ipf/platform/camel/ihe/xds/dispatch/DispatchAuditStrategy.java
@@ -37,6 +37,7 @@ import org.openehealth.ipf.commons.ihe.xds.iti63.Iti63AuditStrategy;
 import org.openehealth.ipf.commons.ihe.xds.iti80.Iti80ServerAuditStrategy;
 import org.openehealth.ipf.commons.ihe.xds.iti86.Iti86AuditStrategy;
 import org.openehealth.ipf.commons.ihe.xds.iti92.Iti92ServerAuditStrategy;
+import org.openehealth.ipf.commons.ihe.xds.pharm1.Pharm1AuditStrategy;
 import org.openehealth.ipf.commons.ihe.xds.rad69.Rad69ServerAuditStrategy;
 import org.openehealth.ipf.commons.ihe.xds.rad75.Rad75ServerAuditStrategy;
 
@@ -83,6 +84,8 @@ public class DispatchAuditStrategy<T extends XdsAuditDataset> extends AuditStrat
                 new Iti63AuditStrategy(true));
         map.put(new QName("urn:ihe:iti:xds-b:2007", "DocumentRepository_CrossGatewayDocumentProvide"),
                 new Iti80ServerAuditStrategy());
+        map.put(new QName("urn:ihe:iti:xds-b:2007", "CommunityPharmacyManager_QueryPharmacyDocuments"),
+                new Pharm1AuditStrategy(true));
         map.put(new QName("urn:ihe:iti:rmd:2017", "DocumentRepository_RemoveDocuments"),
                 new Iti86AuditStrategy(true));
         map.put(new QName("urn:ihe:iti:rmu:2018", "UpdateResponder_RestrictedUpdateDocumentSet"),

--- a/platform-camel/ihe/xds/src/test/java/org/openehealth/ipf/platform/camel/ihe/xds/dispatch/DispatchInPayloadExtractorInterceptor.java
+++ b/platform-camel/ihe/xds/src/test/java/org/openehealth/ipf/platform/camel/ihe/xds/dispatch/DispatchInPayloadExtractorInterceptor.java
@@ -34,6 +34,7 @@ public class DispatchInPayloadExtractorInterceptor extends InPayloadExtractorInt
         SET.add(new QName("urn:ihe:iti:xds-b:2007", "RespondingGateway_CrossGatewayQuery"));
         SET.add(new QName("urn:ihe:iti:xds-b:2007", "DocumentRegistry_MultiPatientStoredQuery"));
         SET.add(new QName("urn:ihe:iti:xds-b:2007", "RespondingGateway_CrossGatewayFetch"));
+        SET.add(new QName("urn:ihe:iti:xds-b:2007", "CommunityPharmacyManager_QueryPharmacyDocuments"));
     }
 
 

--- a/platform-camel/ihe/xds/src/test/java/org/openehealth/ipf/platform/camel/ihe/xds/dispatch/DispatchRouteBuilder.java
+++ b/platform-camel/ihe/xds/src/test/java/org/openehealth/ipf/platform/camel/ihe/xds/dispatch/DispatchRouteBuilder.java
@@ -40,6 +40,8 @@ public class DispatchRouteBuilder extends RouteBuilder {
                     .to("direct:handle-iti18")
                 .when(header(CxfConstants.OPERATION_NAME).isEqualTo("DocumentRegistry_RegisterDocumentSet-b"))
                     .to("direct:handle-iti42")
+                .when(header(CxfConstants.OPERATION_NAME).isEqualTo("CommunityPharmacyManager_QueryPharmacyDocuments"))
+                    .to("direct:handle-pharm1")
                 .otherwise()
                     .to("direct:unsupportedOperation");
 
@@ -64,6 +66,17 @@ public class DispatchRouteBuilder extends RouteBuilder {
                 })
                 .convertBodyTo(RegistryResponseType.class)
                 .process(XdsCamelValidators.iti42ResponseValidator());
+
+        from("direct:handle-pharm1")
+                .process(XdsCamelValidators.pharm1RequestValidator())
+                .transform(new Expression() {
+                    @Override
+                    public <T> T evaluate(Exchange exchange, Class<T> type) {
+                        return (T) SampleData.createQueryResponseWithObjRef();
+                    }
+                })
+                .convertBodyTo(AdhocQueryResponse.class)
+                .process(XdsCamelValidators.pharm1ResponseValidator());
 
         from("direct:unsupportedOperation")
                 .throwException(new SOAPFaultException(SOAPFactory.newInstance().createFault(

--- a/platform-camel/ihe/xds/src/test/java/org/openehealth/ipf/platform/camel/ihe/xds/dispatch/DocumentRegistryPortType.java
+++ b/platform-camel/ihe/xds/src/test/java/org/openehealth/ipf/platform/camel/ihe/xds/dispatch/DocumentRegistryPortType.java
@@ -79,4 +79,22 @@ public interface DocumentRegistryPortType {
             SubmitObjectsRequest body
     );
 
+    /**
+     * Performs a stored query according to the PHARM-1 specification.
+     * @param body
+     *          the query request.
+     * @return the query response.
+     */
+    @WebResult(name = "AdhocQueryResponse",
+            targetNamespace = "urn:oasis:names:tc:ebxml-regrep:xsd:query:3.0",
+            partName = "body")
+    @Action(input = "urn:ihe:pharm:cmpd:2010:QueryPharmacyDocuments",
+            output = "urn:ihe:pharm:cmpd:2010:QueryPharmacyDocumentsResponse")
+    @WebMethod(operationName = "CommunityPharmacyManager_QueryPharmacyDocuments")
+    public AdhocQueryResponse communityPharmacyManagerQueryPharmacyDocuments(
+            @WebParam(partName = "body",
+                    name = "AdhocQueryRequest",
+                    targetNamespace = "urn:oasis:names:tc:ebxml-regrep:xsd:query:3.0")
+            AdhocQueryRequest body
+    );
 }

--- a/platform-camel/ihe/xds/src/test/java/org/openehealth/ipf/platform/camel/ihe/xds/dispatch/TestDispatch.java
+++ b/platform-camel/ihe/xds/src/test/java/org/openehealth/ipf/platform/camel/ihe/xds/dispatch/TestDispatch.java
@@ -33,6 +33,7 @@ public class TestDispatch extends XdsStandardTestContainer {
 
     final String ITI_18_SERVICE_URI = "xds-iti18://localhost:8888/xdsRegistry";
     final String ITI_42_SERVICE_URI = "xds-iti42://localhost:8888/xdsRegistry";
+    final String PHARM_1_SERVICE_URL = "xds-pharm1://localhost:8888/xdsRegistry";
 
     public static void main(String... args) {
         startServer(new CXFServlet(), CONTEXT_DESCRIPTOR, false, 8889);
@@ -48,8 +49,9 @@ public class TestDispatch extends XdsStandardTestContainer {
     public void testXdsDispatch() {
         send(ITI_42_SERVICE_URI, SampleData.createRegisterDocumentSet());
         send(ITI_18_SERVICE_URI, SampleData.createFindDocumentsQuery());
+        send(PHARM_1_SERVICE_URL, SampleData.createFindDispensesQuery());
         AbstractMockedAuditMessageQueue queue = getAuditSender();
         List<AuditMessage> messages = queue.getMessages();
-        assertEquals(4, messages.size());
+        assertEquals(6, messages.size());
     }
 }

--- a/platform-camel/ihe/xds/src/test/resources/dispatch/DocumentRegistry.wsdl
+++ b/platform-camel/ihe/xds/src/test/resources/dispatch/DocumentRegistry.wsdl
@@ -57,6 +57,11 @@
         <part name="body" element="rs:RegistryResponse"/>
     </message>
 
+    <message name="QueryPharmacyDocuments_Message">
+        <documentation>Query Pharmacy Documents</documentation>
+        <part name="body" element="query:AdhocQueryRequest"/>
+    </message>
+
     <portType name="DocumentRegistry_PortType">
         <operation name="DocumentRegistry_RegistryStoredQuery">
             <input message="ihe:RegistryStoredQuery_Message"
@@ -70,6 +75,13 @@
                    wsam:Action="urn:ihe:iti:2007:RegisterDocumentSet-b"/>
             <output message="ihe:RegisterDocumentSet-bResponse_Message"
                     wsam:Action="urn:ihe:iti:2007:RegisterDocumentSet-bResponse"/>
+        </operation>
+
+        <operation name="CommunityPharmacyManager_QueryPharmacyDocuments">
+            <input message="ihe:QueryPharmacyDocuments_Message"
+                   wsam:Action="urn:ihe:pharm:cmpd:2010:QueryPharmacyDocuments"/>
+            <output message="ihe:RegistryStoredQueryResponse_Message"
+                    wsam:Action="urn:ihe:pharm:cmpd:2010:QueryPharmacyDocumentsResponse"/>
         </operation>
     </portType>
 
@@ -86,6 +98,16 @@
         </operation>
 
         <operation name="DocumentRegistry_RegisterDocumentSet-b">
+            <soap12:operation soapActionRequired="false"/>
+            <input>
+                <soap12:body use="literal"/>
+            </input>
+            <output>
+                <soap12:body use="literal"/>
+            </output>
+        </operation>
+
+        <operation name="CommunityPharmacyManager_QueryPharmacyDocuments">
             <soap12:operation soapActionRequired="false"/>
             <input>
                 <soap12:body use="literal"/>

--- a/platform-camel/ihe/xds/src/test/resources/pharm-1.xml
+++ b/platform-camel/ihe/xds/src/test/resources/pharm-1.xml
@@ -1,0 +1,32 @@
+<!--
+    Copyright 2009 the original author or authors. Licensed under the Apache
+    License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable
+    law or agreed to in writing, software distributed under the License is
+    distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the specific
+    language governing permissions and limitations under the License.
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:camel="http://camel.apache.org/schema/spring"
+       xsi:schemaLocation="
+http://www.springframework.org/schema/beans
+http://www.springframework.org/schema/beans/spring-beans.xsd
+http://camel.apache.org/schema/spring
+http://camel.apache.org/schema/spring/camel-spring.xsd">
+
+    <import resource="common-xds-beans.xml"/>
+
+    <bean id="routeBuilder"
+          class="org.openehealth.ipf.platform.camel.ihe.xds.pharm1.Pharm1TestRouteBuilder">
+    </bean>
+
+    <bean id="loggingFeature" class="org.apache.cxf.ext.logging.LoggingFeature" />
+    <bean id="policyFeature" class="org.apache.cxf.ws.policy.WSPolicyFeature" />
+    <bean id="gzipFeature" class="org.apache.cxf.transport.common.gzip.GZIPFeature" />
+    <bean id="fastInfosetFeature" class="org.apache.cxf.feature.FastInfosetFeature" />
+
+</beans>


### PR DESCRIPTION
PHARM-1 is a transaction introduced in the [IHE Pharmacy Technical Framework Supplement: Community Medication Prescription and Dispense](https://www.ihe.net/uploadedFiles/Documents/Pharmacy/IHE_Pharmacy_Suppl_CMPD.pdf). It's based on the ITI-18 transaction and introduce seven new queries that act on CDA eMedication documents.

What has been done:
- [x] Implement the PHARM-1 WSDL, port type, service and component.
- [x] Implement the new stored queries, their mappers and validators, and test them all.
- [x] Implement the audit strategy.
- [x] Test the transaction and the generated audit messages.

The target namespace of the WSDL is "urn:ihe:iti:xds-b:2007", so I implemented it in the XDS namespace. The code is quite close to the ITI-18 implementation, it should not contain too many surprises.

The queries have the following hierarchy:

- _PharmacyDocumentsQuery_ (abstract, extends StoredQuery)
  - FindMedicationListQuery
  - _Pharm1StableDocumentsQuery_ (abstract)
    - FindMedicationTreatmentPlansQuery
    - FindDispensesQuery
    - FindPrescriptionsQuery
    - FindMedicationAdministrationsQuery
    - FindPrescriptionsForValidationQuery
    - FindPrescriptionsForDispenseQuery

The request is a standard AdhocQueryRequest and the response a AdhocQueryResponse.

Quentin