### PR TITLE
Keep MDC context while sending audit records via ExecutorService

### DIFF
--- a/commons/audit/src/main/java/org/openehealth/ipf/commons/audit/queue/AsynchronousAuditMessageQueue.java
+++ b/commons/audit/src/main/java/org/openehealth/ipf/commons/audit/queue/AsynchronousAuditMessageQueue.java
@@ -20,13 +20,15 @@ import org.openehealth.ipf.commons.audit.AuditContext;
 import org.openehealth.ipf.commons.audit.AuditException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.Map;
 
 /**
- * Audit queue that uses an injectable {@link ExecutorService} to asynchonously send away audit events.
+ * Audit queue that uses an injectable {@link ExecutorService} to asynchronously send away audit events.
  * When this queue is {@link #shutdown() shut down}, the executor service is also, waiting for at most
  * {@link #shutdownTimeoutSeconds} until all pending events are sent.
  * <p>
@@ -80,11 +82,17 @@ public class AsynchronousAuditMessageQueue extends AbstractAuditMessageQueue {
     }
 
     private Runnable runnable(AuditContext auditContext, String auditRecord) {
+        // Copy the MDC contextMap to re-use it in the worker thread
+        // See this recommendation here: http://logback.qos.ch/manual/mdc.html#managedThreads
+        Map<String, String> mdcContextMap = MDC.getCopyOfContextMap();
         return () -> {
             try {
+                MDC.setContextMap(mdcContextMap);
                 auditContext.getAuditTransmissionProtocol().send(auditContext, auditRecord);
             } catch (Exception e) {
                 throw new AuditException(e);
+            } finally {
+                MDC.clear();
             }
         };
     }


### PR DESCRIPTION
When sending audit records using the AsynchronousAuditMessageQueue the logs are loosing the MDC context in the worker thread, hence variables such as `camel.breadcrumbId` cannot be used to correlate log lines.

The fix provides a way to overwrite the MDC context from the main thread to the worker thread.