### PR TITLE
submissionset may contain no classification node

### DIFF
--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/responses/QueryResponseTransformer.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/responses/QueryResponseTransformer.java
@@ -138,13 +138,14 @@ public class QueryResponseTransformer {
             foundNonObjRefs = true;
         }
 
-        for (var regPackage : ebXML.getRegistryPackages(Vocabulary.FOLDER_CLASS_NODE)) {
-            response.getFolders().add(folderTransformer.fromEbXML(regPackage));
-            foundNonObjRefs = true;
-        }
-
-        for (var regPackage : ebXML.getRegistryPackages(Vocabulary.SUBMISSION_SET_CLASS_NODE)) {
-            response.getSubmissionSets().add(submissionSetTransformer.fromEbXML(regPackage));
+        var folderPackages = ebXML.getRegistryPackages(Vocabulary.FOLDER_CLASS_NODE);
+        var regPackages = ebXML.getRegistryPackages();
+        for (var regPackage : regPackages) {
+            if (folderPackages!=null && folderPackages.contains(regPackage)) {
+                response.getFolders().add(folderTransformer.fromEbXML(regPackage));
+            } else {
+                response.getSubmissionSets().add(submissionSetTransformer.fromEbXML(regPackage));
+            }
             foundNonObjRefs = true;
         }
 


### PR DESCRIPTION
The XDSTools7 simulators do not classify a SubmissionSet in the RegistryPackage in the ITI-18 response. We think this is conformant to XDS since ITI TF Vol 3 says for 4.2.1.4 Registry Object List:

545 The rim:RegistryObjectList may also contain rim:Classification elements that identify the RegistryPackage elements as a SubmissionSet or Folder. See Sections 4.2.1.2.1 and 4.2.1.3.1. 

We adapted the QueryResponseTransformer that an unclassified RegistryPackage is a SubmissionSetType.

Example P&R Request:
```xml
<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
  <soap:Header>
    <Action xmlns="http://www.w3.org/2005/08/addressing" soap:mustUnderstand="true">
      urn:ihe:iti:2007:ProvideAndRegisterDocumentSet-b
    </Action>
    <MessageID xmlns="http://www.w3.org/2005/08/addressing">
      urn:uuid:8a6b6a44-104d-4fb0-ba18-f70fcb953b91
    </MessageID>
    <To xmlns="http://www.w3.org/2005/08/addressing">
      http://ehealthsuisse.ihe-europe.net:8280/xdstools7/sim/default__ahdis/rep/prb/xds/iti41
    </To>
    <ReplyTo xmlns="http://www.w3.org/2005/08/addressing">
      <Address>
        http://www.w3.org/2005/08/addressing/anonymous
      </Address>
    </ReplyTo>
  </soap:Header>
  <soap:Body>
    <ns4:ProvideAndRegisterDocumentSetRequest xmlns:ns4="urn:ihe:iti:xds-b:2007">
      <ns5:SubmitObjectsRequest xmlns:ns5="urn:oasis:names:tc:ebxml-regrep:xsd:lcm:3.0">
        <ns3:RequestSlotList xmlns:ns3="urn:oasis:names:tc:ebxml-regrep:xsd:rs:3.0"/>
        <ns2:RegistryObjectList xmlns:ns2="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0">
          <ns2:ExtrinsicObject mimeType="text/xml" objectType="urn:uuid:7edca82f-054d-47f2-a032-9b2a5b5186c1" status="urn:oasis:names:tc:ebxml-regrep:StatusType:Approved" id="urn:uuid:6e76393e-ccb3-4208-a7da-78d27b6d490c">
            <ns2:Slot name="creationTime">
              <ns2:ValueList>
                <ns2:Value>
                  20200629115800
                </ns2:Value>
              </ns2:ValueList>
            </ns2:Slot>
            <ns2:Slot name="languageCode">
              <ns2:ValueList>
                <ns2:Value>
                  de-CH
                </ns2:Value>
              </ns2:ValueList>
            </ns2:Slot>
            <ns2:Slot name="size">
              <ns2:ValueList>
                <ns2:Value>
                  309219
                </ns2:Value>
              </ns2:ValueList>
            </ns2:Slot>
            <ns2:Slot name="sourcePatientId">
              <ns2:ValueList>
                <ns2:Value>
                  IHEGREEN-2601^^^&1.3.6.1.4.1.21367.13.20.2000&ISO
                </ns2:Value>
              </ns2:ValueList>
            </ns2:Slot>
            <ns2:Name>
              <ns2:LocalizedString xml:lang="en-US" xmlns:xml="http://www.w3.org/XML/1998/namespace" charset="UTF-8" value="2-7-MedicationCard"/>
            </ns2:Name>
            <ns2:Classification classificationScheme="urn:uuid:41a5887f-8865-4c09-adf7-e362475b143a" classifiedObject="urn:uuid:6e76393e-ccb3-4208-a7da-78d27b6d490c" nodeRepresentation="422735006" id="urn:uuid:f0a0d0da-f67b-49ce-8421-c3f2d0f98504">
              <ns2:Slot name="codingScheme">
                <ns2:ValueList>
                  <ns2:Value>
                    2.16.840.1.113883.6.96
                  </ns2:Value>
                </ns2:ValueList>
              </ns2:Slot>
              <ns2:Name>
                <ns2:LocalizedString xml:lang="en-US" xmlns:xml="http://www.w3.org/XML/1998/namespace" charset="UTF-8" value="Summary clinical document (record artifact)"/>
              </ns2:Name>
            </ns2:Classification>
            <ns2:Classification classificationScheme="urn:uuid:a09d5840-386c-46f2-b5ad-9c3699a4309d" classifiedObject="urn:uuid:6e76393e-ccb3-4208-a7da-78d27b6d490c" nodeRepresentation="urn:ihe:pharm:pml:2013" id="urn:uuid:92f002a4-aa80-417f-80f6-014e6ea7cb11">
              <ns2:Slot name="codingScheme">
                <ns2:ValueList>
                  <ns2:Value>
                    1.3.6.1.4.1.19376.1.2.3
                  </ns2:Value>
                </ns2:ValueList>
              </ns2:Slot>
              <ns2:Name>
                <ns2:LocalizedString xml:lang="en-US" xmlns:xml="http://www.w3.org/XML/1998/namespace" charset="UTF-8" value="Community Medication List"/>
              </ns2:Name>
            </ns2:Classification>
            <ns2:Classification classificationScheme="urn:uuid:f33fb8ac-18af-42cc-ae0e-ed0b0bdb91e1" classifiedObject="urn:uuid:6e76393e-ccb3-4208-a7da-78d27b6d490c" nodeRepresentation="264358009" id="urn:uuid:7faecfd3-b0fb-430e-8086-cca99aeb358e">
              <ns2:Slot name="codingScheme">
                <ns2:ValueList>
                  <ns2:Value>
                    2.16.840.1.113883.6.96
                  </ns2:Value>
                </ns2:ValueList>
              </ns2:Slot>
              <ns2:Name>
                <ns2:LocalizedString xml:lang="en-US" xmlns:xml="http://www.w3.org/XML/1998/namespace" charset="UTF-8" value="General practice premises (environment)"/>
              </ns2:Name>
            </ns2:Classification>
            <ns2:Classification classificationScheme="urn:uuid:cccf5598-8b07-4b77-a05e-ae952c785ead" classifiedObject="urn:uuid:6e76393e-ccb3-4208-a7da-78d27b6d490c" nodeRepresentation="394802001" id="urn:uuid:ce2726bd-7442-4082-b70d-ac0b377b299e">
              <ns2:Slot name="codingScheme">
                <ns2:ValueList>
                  <ns2:Value>
                    2.16.840.1.113883.6.96
                  </ns2:Value>
                </ns2:ValueList>
              </ns2:Slot>
              <ns2:Name>
                <ns2:LocalizedString xml:lang="en-US" xmlns:xml="http://www.w3.org/XML/1998/namespace" charset="UTF-8" value="General medicine (qualifier value)"/>
              </ns2:Name>
            </ns2:Classification>
            <ns2:Classification classificationScheme="urn:uuid:f0306f51-975f-434e-a61c-c59651d33983" classifiedObject="urn:uuid:6e76393e-ccb3-4208-a7da-78d27b6d490c" nodeRepresentation="721912009" id="urn:uuid:e2dfaeb7-209a-46c8-9956-b911ddae15cb">
              <ns2:Slot name="codingScheme">
                <ns2:ValueList>
                  <ns2:Value>
                    2.16.840.1.113883.6.96
                  </ns2:Value>
                </ns2:ValueList>
              </ns2:Slot>
              <ns2:Name>
                <ns2:LocalizedString xml:lang="en-US" xmlns:xml="http://www.w3.org/XML/1998/namespace" charset="UTF-8" value="Medication summary document (record artifact)"/>
              </ns2:Name>
            </ns2:Classification>
            <ns2:Classification classificationScheme="urn:uuid:f4f85eac-e6cb-4883-b524-f2705394840f" classifiedObject="urn:uuid:6e76393e-ccb3-4208-a7da-78d27b6d490c" nodeRepresentation="17621005" id="urn:uuid:7cecc313-8fd6-4cbb-93a6-1b3556788888">
              <ns2:Slot name="codingScheme">
                <ns2:ValueList>
                  <ns2:Value>
                    2.16.840.1.113883.6.96
                  </ns2:Value>
                </ns2:ValueList>
              </ns2:Slot>
              <ns2:Name>
                <ns2:LocalizedString xml:lang="en-US" xmlns:xml="http://www.w3.org/XML/1998/namespace" charset="UTF-8" value="Normal (qualifier value)"/>
              </ns2:Name>
            </ns2:Classification>
            <ns2:ExternalIdentifier registryObject="urn:uuid:6e76393e-ccb3-4208-a7da-78d27b6d490c" identificationScheme="urn:uuid:58a6f841-87b3-4a3e-92fd-a8ffeff98427" value="IHEGREEN-2601^^^&1.3.6.1.4.1.21367.13.20.2000&ISO" id="urn:uuid:281d47ed-23de-445e-93a1-658f5055bc4a">
              <ns2:Name>
                <ns2:LocalizedString value="XDSDocumentEntry.patientId"/>
              </ns2:Name>
            </ns2:ExternalIdentifier>
            <ns2:ExternalIdentifier registryObject="urn:uuid:6e76393e-ccb3-4208-a7da-78d27b6d490c" identificationScheme="urn:uuid:2e82c1f6-a085-4c72-9da3-8640a32e42ab" value="2.25.242899722018806209340773860812087357603" id="urn:uuid:8113d976-beb6-4b01-9021-563267b65b62">
              <ns2:Name>
                <ns2:LocalizedString value="XDSDocumentEntry.uniqueId"/>
              </ns2:Name>
            </ns2:ExternalIdentifier>
          </ns2:ExtrinsicObject>
          <ns2:RegistryPackage id="urn:uuid:7596228b-4644-466e-8388-5434601ad7c8">
            <ns2:Slot name="submissionTime">
              <ns2:ValueList>
                <ns2:Value>
                  20200707120130
                </ns2:Value>
              </ns2:ValueList>
            </ns2:Slot>
            <ns2:Name>
              <ns2:LocalizedString xml:lang="en-US" xmlns:xml="http://www.w3.org/XML/1998/namespace" charset="UTF-8" value="Hello World 2 example"/>
            </ns2:Name>
            <ns2:Classification classificationScheme="urn:uuid:aa543740-bdda-424e-8c96-df4873be8500" classifiedObject="urn:uuid:7596228b-4644-466e-8388-5434601ad7c8" nodeRepresentation="71388002" id="urn:uuid:a4b38795-7608-4272-89e9-78699460b402">
              <ns2:Slot name="codingScheme">
                <ns2:ValueList>
                  <ns2:Value>
                    2.16.840.1.113883.6.96
                  </ns2:Value>
                </ns2:ValueList>
              </ns2:Slot>
              <ns2:Name>
                <ns2:LocalizedString xml:lang="en-US" xmlns:xml="http://www.w3.org/XML/1998/namespace" charset="UTF-8" value="Procedure (procedure)"/>
              </ns2:Name>
            </ns2:Classification>
            <ns2:ExternalIdentifier registryObject="urn:uuid:7596228b-4644-466e-8388-5434601ad7c8" identificationScheme="urn:uuid:6b5aea1a-874d-4603-a4bc-96a0a7b38446" value="IHEGREEN-2601^^^&1.3.6.1.4.1.21367.13.20.2000&ISO" id="urn:uuid:8eed1c19-0b90-4f7d-a628-d4cbdac503f9">
              <ns2:Name>
                <ns2:LocalizedString value="XDSSubmissionSet.patientId"/>
              </ns2:Name>
            </ns2:ExternalIdentifier>
            <ns2:ExternalIdentifier registryObject="urn:uuid:7596228b-4644-466e-8388-5434601ad7c8" identificationScheme="urn:uuid:96fdda7c-d067-4183-912e-bf5ee74998a8" value="1.3.6.1.4.1.12559.11.13.2.6.2952" id="urn:uuid:25972c73-f5de-4c47-8b9a-79f94e2c8987">
              <ns2:Name>
                <ns2:LocalizedString value="XDSSubmissionSet.uniqueId"/>
              </ns2:Name>
            </ns2:ExternalIdentifier>
            <ns2:ExternalIdentifier registryObject="urn:uuid:7596228b-4644-466e-8388-5434601ad7c8" identificationScheme="urn:uuid:554ac39e-e3fe-47fe-b233-965d2a147832" value="1.3.6.1.4.1.12559.11.13.2.5" id="urn:uuid:885567b6-8466-47c2-9065-46fb3f4b9ca4">
              <ns2:Name>
                <ns2:LocalizedString value="XDSSubmissionSet.sourceId"/>
              </ns2:Name>
            </ns2:ExternalIdentifier>
          </ns2:RegistryPackage>
          <ns2:Classification classifiedObject="urn:uuid:7596228b-4644-466e-8388-5434601ad7c8" classificationNode="urn:uuid:a54d6aa5-d40d-43f9-88c5-b4633d873bdd" id="urn:uuid:b4931460-3276-44b6-adbf-18a13fb10b9a"/>
          <ns2:Association associationType="urn:oasis:names:tc:ebxml-regrep:AssociationType:HasMember" sourceObject="urn:uuid:7596228b-4644-466e-8388-5434601ad7c8" targetObject="urn:uuid:6e76393e-ccb3-4208-a7da-78d27b6d490c" id="urn:uuid:c9da44fd-637d-43bf-a818-4503caaabc99">
            <ns2:Slot name="SubmissionSetStatus">
              <ns2:ValueList>
                <ns2:Value>
                  Original
                </ns2:Value>
              </ns2:ValueList>
            </ns2:Slot>
          </ns2:Association>
        </ns2:RegistryObjectList>
      </ns5:SubmitObjectsRequest>
      <ns4:Document id="urn:uuid:6e76393e-ccb3-4208-a7da-78d27b6d490c">
        <xop:Include xmlns:xop="http://www.w3.org/2004/08/xop/include" href="cid:cefd9f7a-0f44-4783-b764-f66f6bae34fd-1@urn%3Aihe%3Aiti%3Axds-b%3A2007"/>
      </ns4:Document>
    </ns4:ProvideAndRegisterDocumentSetRequest>
  </soap:Body>
</soap:Envelope>
```
Response from XDSTools:
http://ehealthsuisse.ihe-europe.net:8280/xdstools7/Xdstools2.html#SimMsgViewer:default__ahdis/reg/sq/2020_07_07_12_08_40_118
without the classificatin node

```xml
<S:Envelope xmlns:S="http://www.w3.org/2003/05/soap-envelope">
  <S:Header>
    <wsa:Action xmlns:wsa="http://www.w3.org/2005/08/addressing" s:mustUnderstand="1" xmlns:s="http://www.w3.org/2003/05/soap-envelope">
      urn:ihe:iti:2007:RegistryStoredQueryResponse
    </wsa:Action>
    <wsa:RelatesTo xmlns:wsa="http://www.w3.org/2005/08/addressing">
      urn:uuid:645564e2-1f44-4563-8f66-7bfb9166f190
    </wsa:RelatesTo>
  </S:Header>
  <S:Body>
    <query:AdhocQueryResponse xmlns:query="urn:oasis:names:tc:ebxml-regrep:xsd:query:3.0" status="urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Success">
      <rim:RegistryObjectList xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0">
        <ns2:RegistryPackage xmlns:ns2="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0" id="urn:uuid:4bfccffc-1029-4196-a825-0da7ba50597d" lid="urn:uuid:4bfccffc-1029-4196-a825-0da7ba50597d" status="urn:oasis:names:tc:ebxml-regrep:StatusType:Approved">
          <ns2:Slot name="submissionTime">
            <ns2:ValueList>
              <ns2:Value>
                20200707120130
              </ns2:Value>
            </ns2:ValueList>
          </ns2:Slot>
          <ns2:Name>
            <ns2:LocalizedString xml:lang="en-US" xmlns:xml="http://www.w3.org/XML/1998/namespace" charset="UTF-8" value="Hello World 2 example"/>
          </ns2:Name>
          <rim:VersionInfo versionName="1"/>
          <ns2:Classification classificationScheme="urn:uuid:aa543740-bdda-424e-8c96-df4873be8500" classifiedObject="urn:uuid:4bfccffc-1029-4196-a825-0da7ba50597d" nodeRepresentation="71388002" id="urn:uuid:f84087c6-48f7-491f-b6f7-00098bbfdd81">
            <ns2:Slot name="codingScheme">
              <ns2:ValueList>
                <ns2:Value>
                  2.16.840.1.113883.6.96
                </ns2:Value>
              </ns2:ValueList>
            </ns2:Slot>
            <ns2:Name>
              <ns2:LocalizedString xml:lang="en-US" xmlns:xml="http://www.w3.org/XML/1998/namespace" charset="UTF-8" value="Procedure (procedure)"/>
            </ns2:Name>
            <rim:VersionInfo versionName="-1"/>
          </ns2:Classification>
          <ns2:ExternalIdentifier registryObject="urn:uuid:4bfccffc-1029-4196-a825-0da7ba50597d" identificationScheme="urn:uuid:6b5aea1a-874d-4603-a4bc-96a0a7b38446" value="IHEGREEN-2601^^^&1.3.6.1.4.1.21367.13.20.2000&ISO" id="urn:uuid:d8847504-4058-4f62-8684-6c100f56c25b">
            <ns2:Name>
              <ns2:LocalizedString value="XDSSubmissionSet.patientId"/>
            </ns2:Name>
            <rim:VersionInfo versionName="-1"/>
          </ns2:ExternalIdentifier>
          <ns2:ExternalIdentifier registryObject="urn:uuid:4bfccffc-1029-4196-a825-0da7ba50597d" identificationScheme="urn:uuid:96fdda7c-d067-4183-912e-bf5ee74998a8" value="1.3.6.1.4.1.12559.11.13.2.6.2952" id="urn:uuid:5374df48-a5eb-46fc-9bdf-3f3b71db551d">
            <ns2:Name>
              <ns2:LocalizedString value="XDSSubmissionSet.uniqueId"/>
            </ns2:Name>
            <rim:VersionInfo versionName="-1"/>
          </ns2:ExternalIdentifier>
          <ns2:ExternalIdentifier registryObject="urn:uuid:4bfccffc-1029-4196-a825-0da7ba50597d" identificationScheme="urn:uuid:554ac39e-e3fe-47fe-b233-965d2a147832" value="1.3.6.1.4.1.12559.11.13.2.5" id="urn:uuid:f21404a7-36a1-4444-acc8-3f82111cd6cc">
            <ns2:Name>
              <ns2:LocalizedString value="XDSSubmissionSet.sourceId"/>
            </ns2:Name>
            <rim:VersionInfo versionName="-1"/>
          </ns2:ExternalIdentifier>
        </ns2:RegistryPackage>
      </rim:RegistryObjectList>
    </query:AdhocQueryResponse>
  </S:Body>
</S:Envelope>
```



