### PR TITLE
More PHARM-1 fixes

### DIFF
--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/PharmacyStableDocumentsQuery.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/requests/query/PharmacyStableDocumentsQuery.java
@@ -53,9 +53,9 @@ public abstract class PharmacyStableDocumentsQuery extends PharmacyDocumentsQuer
     @XmlElement(name = "healthcareFacilityTypeCode")
     @Getter @Setter private List<Code> healthcareFacilityTypeCodes;
     @XmlElement(name = "eventCode")
-    @Getter @Setter private QueryList<Code> eventCodes;
+    @Getter @Setter private List<Code> eventCodes;
     @XmlElement(name = "confidentialityCode")
-    @Getter @Setter private QueryList<Code> confidentialityCodes;
+    @Getter @Setter private List<Code> confidentialityCodes;
     @XmlElement(name = "authorPerson")
     @Getter @Setter private List<String> authorPersons;
 

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/PharmacyStableDocumentsQueryTransformer.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/query/PharmacyStableDocumentsQueryTransformer.java
@@ -80,10 +80,10 @@ abstract class PharmacyStableDocumentsQueryTransformer<T extends PharmacyStableD
         var slots = new QuerySlotHelper(ebXML);
 
         query.setAuthorPersons(slots.toStringList(DOC_ENTRY_AUTHOR_PERSON));
-        query.setConfidentialityCodes(slots.toCodeQueryList(DOC_ENTRY_CONFIDENTIALITY_CODE, DOC_ENTRY_CONFIDENTIALITY_CODE_SCHEME));
+        query.setConfidentialityCodes(slots.toCodeList(DOC_ENTRY_CONFIDENTIALITY_CODE));
         query.getCreationTime().setFrom(slots.toNumber(DOC_ENTRY_CREATION_TIME_FROM));
         query.getCreationTime().setTo(slots.toNumber(DOC_ENTRY_CREATION_TIME_TO));
-        query.setEventCodes(slots.toCodeQueryList(DOC_ENTRY_EVENT_CODE, DOC_ENTRY_EVENT_CODE_SCHEME));
+        query.setEventCodes(slots.toCodeList(DOC_ENTRY_EVENT_CODE));
         query.setHealthcareFacilityTypeCodes(slots.toCodeList(DOC_ENTRY_HEALTHCARE_FACILITY_TYPE_CODE));
         query.setPracticeSettingCodes(slots.toCodeList(DOC_ENTRY_PRACTICE_SETTING_CODE));
         query.setUniqueIds(slots.toStringList(DOC_ENTRY_UNIQUE_ID));

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/validate/query/ChoiceValidation.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/validate/query/ChoiceValidation.java
@@ -33,20 +33,24 @@ import static org.openehealth.ipf.commons.ihe.xds.core.validate.ValidationMessag
 /**
  * Query parameter validation to ensure that only one of the given parameters is specified.
  * Also has the "either ... or ... " check to avoid the case that all parameters haven't a
- * value set.
+ * value set if it's not marked as optional.
  * @author Jens Riemschneider
  */
 public class ChoiceValidation implements QueryParameterValidation {
     private final QueryParameter[] params;
+    private final boolean optional;
 
     /**
      * Constructs a validation object.
      * @param params
      *          parameters to validate.
+     * @param optional
+     *          whether all parameters are optional ({@code true}) or one parameter must be specified ({@code false}).
      */
-    public ChoiceValidation(QueryParameter... params) {
+    public ChoiceValidation(boolean optional, QueryParameter... params) {
         notNull(params, "params cannot be null");        
         this.params = params;
+        this.optional = optional;
     }
 
     @Override
@@ -60,7 +64,7 @@ public class ChoiceValidation implements QueryParameterValidation {
                 .filter(Objects::nonNull)
                 .count();
 
-        if (count == 0L) {
+        if (!this.optional && count == 0L) {
             throw new XDSMetaDataException(MISSING_REQUIRED_QUERY_PARAMETER, "one of " + paramSlotNames);
         }
         if (count > 1L) {

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/validate/requests/AdhocQueryRequestValidator.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/validate/requests/AdhocQueryRequestValidator.java
@@ -369,7 +369,7 @@ public class AdhocQueryRequestValidator implements Validator<EbXMLAdhocQueryRequ
                         new NumberValidation(DOC_ENTRY_SERVICE_START_TO, timeValidator),
                         new NumberValidation(DOC_ENTRY_SERVICE_END_FROM, timeValidator),
                         new NumberValidation(DOC_ENTRY_SERVICE_END_TO, timeValidator),
-                        new QueryListCodeValidation(DOC_ENTRY_FORMAT_CODE, DOC_ENTRY_FORMAT_CODE_SCHEME),
+                        new CodeValidation(DOC_ENTRY_FORMAT_CODE),
                         new StatusValidation(DOC_ENTRY_STATUS),
                         new DocumentEntryTypeValidation(),
                 };

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/validate/requests/AdhocQueryRequestValidator.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/validate/requests/AdhocQueryRequestValidator.java
@@ -356,8 +356,8 @@ public class AdhocQueryRequestValidator implements Validator<EbXMLAdhocQueryRequ
                         new NumberValidation(DOC_ENTRY_SERVICE_STOP_TIME_FROM, timeValidator),
                         new NumberValidation(DOC_ENTRY_SERVICE_STOP_TIME_TO, timeValidator),
                         new CodeValidation(DOC_ENTRY_HEALTHCARE_FACILITY_TYPE_CODE),
-                        new QueryListCodeValidation(DOC_ENTRY_EVENT_CODE, DOC_ENTRY_EVENT_CODE_SCHEME),
-                        new QueryListCodeValidation(DOC_ENTRY_CONFIDENTIALITY_CODE, DOC_ENTRY_CONFIDENTIALITY_CODE_SCHEME),
+                        new CodeValidation(DOC_ENTRY_EVENT_CODE),
+                        new CodeValidation(DOC_ENTRY_CONFIDENTIALITY_CODE),
                         new StringListValidation(DOC_ENTRY_AUTHOR_PERSON, nopValidator),
                         new StatusValidation(DOC_ENTRY_STATUS),
                 };

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/validate/requests/AdhocQueryRequestValidator.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/validate/requests/AdhocQueryRequestValidator.java
@@ -269,7 +269,7 @@ public class AdhocQueryRequestValidator implements Validator<EbXMLAdhocQueryRequ
             case GET_DOCUMENTS:
                 return new QueryParameterValidation[]{
                         new HomeCommunityIdValidation(requireHomeCommunityId),
-                        new ChoiceValidation(DOC_ENTRY_UUID, DOC_ENTRY_UNIQUE_ID, DOC_ENTRY_LOGICAL_ID),
+                        new ChoiceValidation(false, DOC_ENTRY_UUID, DOC_ENTRY_UNIQUE_ID, DOC_ENTRY_LOGICAL_ID),
                         new StringListValidation(DOC_ENTRY_UUID, nopValidator),
                         new StringListValidation(DOC_ENTRY_UNIQUE_ID, nopValidator),
                 };
@@ -277,7 +277,7 @@ public class AdhocQueryRequestValidator implements Validator<EbXMLAdhocQueryRequ
             case GET_DOCUMENTS_AND_ASSOCIATIONS:
                 return new QueryParameterValidation[]{
                         new HomeCommunityIdValidation(requireHomeCommunityId),
-                        new ChoiceValidation(DOC_ENTRY_UUID, DOC_ENTRY_UNIQUE_ID),
+                        new ChoiceValidation(false, DOC_ENTRY_UUID, DOC_ENTRY_UNIQUE_ID),
                         new StringListValidation(DOC_ENTRY_UUID, nopValidator),
                         new StringListValidation(DOC_ENTRY_UNIQUE_ID, nopValidator),
                 };
@@ -285,7 +285,7 @@ public class AdhocQueryRequestValidator implements Validator<EbXMLAdhocQueryRequ
             case GET_FOLDERS_FOR_DOCUMENT:
                 return new QueryParameterValidation[]{
                         new HomeCommunityIdValidation(requireHomeCommunityId),
-                        new ChoiceValidation(DOC_ENTRY_UUID, DOC_ENTRY_UNIQUE_ID),
+                        new ChoiceValidation(false, DOC_ENTRY_UUID, DOC_ENTRY_UNIQUE_ID),
                         new StringValidation(DOC_ENTRY_UUID, nopValidator, true),
                         new StringValidation(DOC_ENTRY_UNIQUE_ID, nopValidator, true),
                 };
@@ -293,7 +293,7 @@ public class AdhocQueryRequestValidator implements Validator<EbXMLAdhocQueryRequ
             case GET_FOLDERS:
                 return new QueryParameterValidation[]{
                         new HomeCommunityIdValidation(requireHomeCommunityId),
-                        new ChoiceValidation(FOLDER_UUID, FOLDER_UNIQUE_ID, FOLDER_LOGICAL_ID),
+                        new ChoiceValidation(false, FOLDER_UUID, FOLDER_UNIQUE_ID, FOLDER_LOGICAL_ID),
                         new StringListValidation(FOLDER_UUID, nopValidator),
                         new StringListValidation(FOLDER_UNIQUE_ID, nopValidator),
                 };
@@ -308,7 +308,7 @@ public class AdhocQueryRequestValidator implements Validator<EbXMLAdhocQueryRequ
             case GET_SUBMISSION_SET_AND_CONTENTS:
                 return new QueryParameterValidation[]{
                         new HomeCommunityIdValidation(requireHomeCommunityId),
-                        new ChoiceValidation(SUBMISSION_SET_UUID, SUBMISSION_SET_UNIQUE_ID),
+                        new ChoiceValidation(false, SUBMISSION_SET_UUID, SUBMISSION_SET_UNIQUE_ID),
                         new StringValidation(SUBMISSION_SET_UUID, nopValidator, true),
                         new StringValidation(SUBMISSION_SET_UNIQUE_ID, nopValidator, true),
                         new QueryListCodeValidation(DOC_ENTRY_CONFIDENTIALITY_CODE, DOC_ENTRY_CONFIDENTIALITY_CODE_SCHEME),
@@ -319,7 +319,7 @@ public class AdhocQueryRequestValidator implements Validator<EbXMLAdhocQueryRequ
             case GET_FOLDER_AND_CONTENTS:
                 return new QueryParameterValidation[]{
                         new HomeCommunityIdValidation(requireHomeCommunityId),
-                        new ChoiceValidation(FOLDER_UUID, FOLDER_UNIQUE_ID),
+                        new ChoiceValidation(false, FOLDER_UUID, FOLDER_UNIQUE_ID),
                         new StringValidation(FOLDER_UUID, nopValidator, true),
                         new StringValidation(FOLDER_UNIQUE_ID, nopValidator, true),
                         new QueryListCodeValidation(DOC_ENTRY_CONFIDENTIALITY_CODE, DOC_ENTRY_CONFIDENTIALITY_CODE_SCHEME),
@@ -330,7 +330,7 @@ public class AdhocQueryRequestValidator implements Validator<EbXMLAdhocQueryRequ
             case GET_RELATED_DOCUMENTS:
                 return new QueryParameterValidation[]{
                         new HomeCommunityIdValidation(requireHomeCommunityId),
-                        new ChoiceValidation(DOC_ENTRY_UUID, DOC_ENTRY_UNIQUE_ID),
+                        new ChoiceValidation(false, DOC_ENTRY_UUID, DOC_ENTRY_UNIQUE_ID),
                         new StringValidation(DOC_ENTRY_UUID, nopValidator, true),
                         new StringValidation(DOC_ENTRY_UNIQUE_ID, nopValidator, true),
                         new AssociationValidation(ASSOCIATION_TYPE),
@@ -345,7 +345,7 @@ public class AdhocQueryRequestValidator implements Validator<EbXMLAdhocQueryRequ
             case FIND_PRESCRIPTIONS_FOR_DISPENSE:
                 return new QueryParameterValidation[]{
                         new StringValidation(DOC_ENTRY_PATIENT_ID, cxValidator, false),
-                        new ChoiceValidation(DOC_ENTRY_UUID, DOC_ENTRY_UNIQUE_ID),
+                        new ChoiceValidation(true, DOC_ENTRY_UUID, DOC_ENTRY_UNIQUE_ID),
                         new StringListValidation(FOLDER_UUID, nopValidator),
                         new StringListValidation(FOLDER_UNIQUE_ID, nopValidator),
                         new CodeValidation(DOC_ENTRY_PRACTICE_SETTING_CODE),

--- a/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/SampleData.java
+++ b/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/SampleData.java
@@ -753,12 +753,7 @@ public abstract class SampleData {
 
         query.setPatientId(new Identifiable("id3", new AssigningAuthority("1.3")));
         query.setHomeCommunityId("12.21.41");
-        final var confidentialityCodes = new QueryList<Code>();
-        confidentialityCodes.getOuterList().add(
-                Arrays.asList(new Code("code10", null, "scheme10"), new Code("code11", null, "scheme11")));
-        confidentialityCodes.getOuterList().add(
-                Collections.singletonList(new Code("code12", null, "scheme12")));
-        query.setConfidentialityCodes(confidentialityCodes);
+        query.setConfidentialityCodes(Arrays.asList(new Code("code10", null, "scheme10"), new Code("code11", null, "scheme11")));
         query.getCreationTime().setFrom("1980");
         query.getCreationTime().setTo("1981");
         query.getServiceStartTime().setFrom("1982");
@@ -769,12 +764,7 @@ public abstract class SampleData {
         query.setUuids(Arrays.asList("uuid1", "uuid2"));
         query.setPracticeSettingCodes(Arrays.asList(new Code("code3", null, "scheme3"), new Code("code4", null, "scheme4")));
         query.setHealthcareFacilityTypeCodes(Arrays.asList(new Code("code5", null, "scheme5"), new Code("code6", null, "scheme6")));
-        final var eventCodes = new QueryList<Code>();
-        eventCodes.getOuterList().add(
-                Arrays.asList(new Code("code7", null, "scheme7"), new Code("code8", null, "scheme8")));
-        eventCodes.getOuterList().add(
-                Collections.singletonList(new Code("code9", null, "scheme9")));
-        query.setEventCodes(eventCodes);
+        query.setEventCodes(Arrays.asList(new Code("code7", null, "scheme7"), new Code("code8", null, "scheme8")));
         query.setAuthorPersons(Arrays.asList("per'son1", "person2"));
 
         return new QueryRegistry(query);
@@ -788,12 +778,7 @@ public abstract class SampleData {
 
         query.setPatientId(new Identifiable("id3", new AssigningAuthority("1.3")));
         query.setHomeCommunityId("urn:oid:1.2.3.14.15.926");
-        final var confidentialityCodes = new QueryList<Code>();
-        confidentialityCodes.getOuterList().add(
-                Arrays.asList(new Code("code10", null, "scheme10"), new Code("code11", null, "scheme11")));
-        confidentialityCodes.getOuterList().add(
-                Collections.singletonList(new Code("code12", null, "scheme12")));
-        query.setConfidentialityCodes(confidentialityCodes);
+        query.setConfidentialityCodes(Arrays.asList(new Code("code10", null, "scheme10"), new Code("code11", null, "scheme11")));
         query.getCreationTime().setFrom("1980");
         query.getCreationTime().setTo("1981");
         query.getServiceStartTime().setFrom("1982");
@@ -804,12 +789,7 @@ public abstract class SampleData {
         query.setUniqueIds(Arrays.asList("uniqueId1", "uniqueId2"));
         query.setPracticeSettingCodes(Arrays.asList(new Code("code3", null, "scheme3"), new Code("code4", null, "scheme4")));
         query.setHealthcareFacilityTypeCodes(Arrays.asList(new Code("code5", null, "scheme5"), new Code("code6", null, "scheme6")));
-        final var eventCodes = new QueryList<Code>();
-        eventCodes.getOuterList().add(
-                Arrays.asList(new Code("code7", null, "scheme7"), new Code("code8", null, "scheme8")));
-        eventCodes.getOuterList().add(
-                Collections.singletonList(new Code("code9", null, "scheme9")));
-        query.setEventCodes(eventCodes);
+        query.setEventCodes(Arrays.asList(new Code("code7", null, "scheme7"), new Code("code8", null, "scheme8")));
         query.setAuthorPersons(Arrays.asList("per'son1", "person2"));
 
         return new QueryRegistry(query);

--- a/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/ebxml30/FindDispensesQueryTransformerTest.java
+++ b/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/ebxml30/FindDispensesQueryTransformerTest.java
@@ -24,7 +24,6 @@ import org.openehealth.ipf.commons.ihe.xds.core.metadata.AvailabilityStatus;
 import org.openehealth.ipf.commons.ihe.xds.core.metadata.Code;
 import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
 import org.openehealth.ipf.commons.ihe.xds.core.requests.query.FindDispensesQuery;
-import org.openehealth.ipf.commons.ihe.xds.core.requests.query.QueryList;
 import org.openehealth.ipf.commons.ihe.xds.core.requests.query.QueryType;
 import org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryParameter;
 import org.openehealth.ipf.commons.ihe.xds.core.transform.requests.query.FindDispensesQueryTransformer;
@@ -51,12 +50,7 @@ public class FindDispensesQueryTransformerTest {
         query = new FindDispensesQuery();
         query.setPatientId(new Identifiable("id3", new AssigningAuthority("uni3", "uniType3")));
         query.setHomeCommunityId("12.21.41");
-        var confidentialityCodes = new QueryList<Code>();
-        confidentialityCodes.getOuterList().add(
-                Arrays.asList(new Code("code10", null, "scheme10"), new Code("code11", null, "scheme11")));
-        confidentialityCodes.getOuterList().add(
-                Collections.singletonList(new Code("code12", null, "scheme12")));
-        query.setConfidentialityCodes(confidentialityCodes);
+        query.setConfidentialityCodes(Arrays.asList(new Code("code10", null, "scheme10"), new Code("code11", null, "scheme11")));
         query.getCreationTime().setFrom("1980");
         query.getCreationTime().setTo("1981");
         query.getServiceStartTime().setFrom("1982");
@@ -68,12 +62,7 @@ public class FindDispensesQueryTransformerTest {
         query.setUniqueIds(Arrays.asList("uniqueId1", "uniqueId2"));
         query.setPracticeSettingCodes(Arrays.asList(new Code("code3", null, "scheme3"), new Code("code4", null, "scheme4")));
         query.setHealthcareFacilityTypeCodes(Arrays.asList(new Code("code5", null, "scheme5"), new Code("code6", null, "scheme6")));
-        var eventCodes = new QueryList<Code>();
-        eventCodes.getOuterList().add(
-                Arrays.asList(new Code("code7", null, "scheme7"), new Code("code8", null, "scheme8")));
-        eventCodes.getOuterList().add(
-                Collections.singletonList(new Code("code9", null, "scheme9")));
-        query.setEventCodes(eventCodes);
+        query.setEventCodes(Arrays.asList(new Code("code7", null, "scheme7"), new Code("code8", null, "scheme8")));
         query.setAuthorPersons(Arrays.asList("per'son1", "person2"));
 
         ebXML = new EbXMLFactory30().createAdhocQueryRequest();
@@ -87,10 +76,8 @@ public class FindDispensesQueryTransformerTest {
         assertEquals("12.21.41", ebXML.getHome());
         assertEquals(Collections.singletonList("'id3^^^&uni3&uniType3'"),
                 ebXML.getSlotValues(QueryParameter.DOC_ENTRY_PATIENT_ID.getSlotName()));
-        var confidentialitySlots = ebXML.getSlots(QueryParameter.DOC_ENTRY_CONFIDENTIALITY_CODE.getSlotName());
-        assertEquals(2, confidentialitySlots.size());
-        assertEquals(Arrays.asList("('code10^^scheme10')", "('code11^^scheme11')"), confidentialitySlots.get(0).getValueList());
-        assertEquals(Collections.singletonList("('code12^^scheme12')"), confidentialitySlots.get(1).getValueList());
+        assertEquals(Arrays.asList("('code10^^scheme10')", "('code11^^scheme11')"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_CONFIDENTIALITY_CODE.getSlotName()));
         assertEquals(Collections.singletonList("1980"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_CREATION_TIME_FROM.getSlotName()));
         assertEquals(Collections.singletonList("1981"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_CREATION_TIME_TO.getSlotName()));
         assertEquals(Collections.singletonList("1982"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_SERVICE_START_TIME_FROM.getSlotName()));
@@ -105,10 +92,8 @@ public class FindDispensesQueryTransformerTest {
                 ebXML.getSlotValues(QueryParameter.DOC_ENTRY_PRACTICE_SETTING_CODE.getSlotName()));
         assertEquals(Arrays.asList("('code5^^scheme5')", "('code6^^scheme6')"),
                 ebXML.getSlotValues(QueryParameter.DOC_ENTRY_HEALTHCARE_FACILITY_TYPE_CODE.getSlotName()));
-        var eventSlots = ebXML.getSlots(QueryParameter.DOC_ENTRY_EVENT_CODE.getSlotName());
-        assertEquals(2, eventSlots.size());
-        assertEquals(Arrays.asList("('code7^^scheme7')", "('code8^^scheme8')"), eventSlots.get(0).getValueList());
-        assertEquals(Collections.singletonList("('code9^^scheme9')"), eventSlots.get(1).getValueList());
+        assertEquals(Arrays.asList("('code7^^scheme7')", "('code8^^scheme8')"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_EVENT_CODE.getSlotName()));
         assertEquals(Arrays.asList("('per''son1')", "('person2')"),
                 ebXML.getSlotValues(QueryParameter.DOC_ENTRY_AUTHOR_PERSON.getSlotName()));
     }

--- a/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/ebxml30/FindMedicationAdministrationsTransformerTest.java
+++ b/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/ebxml30/FindMedicationAdministrationsTransformerTest.java
@@ -24,7 +24,6 @@ import org.openehealth.ipf.commons.ihe.xds.core.metadata.AvailabilityStatus;
 import org.openehealth.ipf.commons.ihe.xds.core.metadata.Code;
 import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
 import org.openehealth.ipf.commons.ihe.xds.core.requests.query.FindMedicationAdministrationsQuery;
-import org.openehealth.ipf.commons.ihe.xds.core.requests.query.QueryList;
 import org.openehealth.ipf.commons.ihe.xds.core.requests.query.QueryType;
 import org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryParameter;
 import org.openehealth.ipf.commons.ihe.xds.core.transform.requests.query.FindMedicationAdministrationsQueryTransformer;
@@ -51,12 +50,7 @@ public class FindMedicationAdministrationsTransformerTest {
         query = new FindMedicationAdministrationsQuery();
         query.setPatientId(new Identifiable("id1", new AssigningAuthority("uni1", "uniType1")));
         query.setHomeCommunityId("12.21.41");
-        var confidentialityCodes = new QueryList<Code>();
-        confidentialityCodes.getOuterList().add(
-                Arrays.asList(new Code("code10", null, "scheme10"), new Code("code11", null, "scheme11")));
-        confidentialityCodes.getOuterList().add(
-                Collections.singletonList(new Code("code12", null, "scheme12")));
-        query.setConfidentialityCodes(confidentialityCodes);
+        query.setConfidentialityCodes(Arrays.asList(new Code("code10", null, "scheme10"), new Code("code11", null, "scheme11")));
         query.getCreationTime().setFrom("1980");
         query.getCreationTime().setTo("1981");
         query.getServiceStartTime().setFrom("1982");
@@ -68,12 +62,7 @@ public class FindMedicationAdministrationsTransformerTest {
         query.setUniqueIds(Arrays.asList("uniqueId1", "uniqueId2"));
         query.setPracticeSettingCodes(Arrays.asList(new Code("code3", null, "scheme3"), new Code("code4", null, "scheme4")));
         query.setHealthcareFacilityTypeCodes(Arrays.asList(new Code("code5", null, "scheme5"), new Code("code6", null, "scheme6")));
-        var eventCodes = new QueryList<Code>();
-        eventCodes.getOuterList().add(
-                Arrays.asList(new Code("code7", null, "scheme7"), new Code("code8", null, "scheme8")));
-        eventCodes.getOuterList().add(
-                Collections.singletonList(new Code("code9", null, "scheme9")));
-        query.setEventCodes(eventCodes);
+        query.setEventCodes(Arrays.asList(new Code("code7", null, "scheme7"), new Code("code8", null, "scheme8")));
         query.setAuthorPersons(Arrays.asList("per'son1", "person2"));
 
         ebXML = new EbXMLFactory30().createAdhocQueryRequest();
@@ -87,10 +76,8 @@ public class FindMedicationAdministrationsTransformerTest {
         assertEquals("12.21.41", ebXML.getHome());
         assertEquals(Collections.singletonList("'id1^^^&uni1&uniType1'"),
                 ebXML.getSlotValues(QueryParameter.DOC_ENTRY_PATIENT_ID.getSlotName()));
-        var confidentialitySlots = ebXML.getSlots(QueryParameter.DOC_ENTRY_CONFIDENTIALITY_CODE.getSlotName());
-        assertEquals(2, confidentialitySlots.size());
-        assertEquals(Arrays.asList("('code10^^scheme10')", "('code11^^scheme11')"), confidentialitySlots.get(0).getValueList());
-        assertEquals(Collections.singletonList("('code12^^scheme12')"), confidentialitySlots.get(1).getValueList());
+        assertEquals(Arrays.asList("('code10^^scheme10')", "('code11^^scheme11')"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_CONFIDENTIALITY_CODE.getSlotName()));
         assertEquals(Collections.singletonList("1980"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_CREATION_TIME_FROM.getSlotName()));
         assertEquals(Collections.singletonList("1981"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_CREATION_TIME_TO.getSlotName()));
         assertEquals(Collections.singletonList("1982"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_SERVICE_START_TIME_FROM.getSlotName()));
@@ -105,10 +92,8 @@ public class FindMedicationAdministrationsTransformerTest {
                 ebXML.getSlotValues(QueryParameter.DOC_ENTRY_PRACTICE_SETTING_CODE.getSlotName()));
         assertEquals(Arrays.asList("('code5^^scheme5')", "('code6^^scheme6')"),
                 ebXML.getSlotValues(QueryParameter.DOC_ENTRY_HEALTHCARE_FACILITY_TYPE_CODE.getSlotName()));
-        var eventSlots = ebXML.getSlots(QueryParameter.DOC_ENTRY_EVENT_CODE.getSlotName());
-        assertEquals(2, eventSlots.size());
-        assertEquals(Arrays.asList("('code7^^scheme7')", "('code8^^scheme8')"), eventSlots.get(0).getValueList());
-        assertEquals(Collections.singletonList("('code9^^scheme9')"), eventSlots.get(1).getValueList());
+        assertEquals(Arrays.asList("('code7^^scheme7')", "('code8^^scheme8')"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_EVENT_CODE.getSlotName()));
         assertEquals(Arrays.asList("('per''son1')", "('person2')"),
                 ebXML.getSlotValues(QueryParameter.DOC_ENTRY_AUTHOR_PERSON.getSlotName()));
     }

--- a/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/ebxml30/FindMedicationTreatmentPlansQueryTransformerTest.java
+++ b/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/ebxml30/FindMedicationTreatmentPlansQueryTransformerTest.java
@@ -24,7 +24,6 @@ import org.openehealth.ipf.commons.ihe.xds.core.metadata.AvailabilityStatus;
 import org.openehealth.ipf.commons.ihe.xds.core.metadata.Code;
 import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
 import org.openehealth.ipf.commons.ihe.xds.core.requests.query.FindMedicationTreatmentPlansQuery;
-import org.openehealth.ipf.commons.ihe.xds.core.requests.query.QueryList;
 import org.openehealth.ipf.commons.ihe.xds.core.requests.query.QueryType;
 import org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryParameter;
 import org.openehealth.ipf.commons.ihe.xds.core.transform.requests.query.FindMedicationTreatmentPlansQueryTransformer;
@@ -51,12 +50,7 @@ public class FindMedicationTreatmentPlansQueryTransformerTest {
         query = new FindMedicationTreatmentPlansQuery();
         query.setPatientId(new Identifiable("id1", new AssigningAuthority("uni1", "uniType1")));
         query.setHomeCommunityId("12.21.41");
-        var confidentialityCodes = new QueryList<Code>();
-        confidentialityCodes.getOuterList().add(
-                Arrays.asList(new Code("code10", null, "scheme10"), new Code("code11", null, "scheme11")));
-        confidentialityCodes.getOuterList().add(
-                Collections.singletonList(new Code("code12", null, "scheme12")));
-        query.setConfidentialityCodes(confidentialityCodes);
+        query.setConfidentialityCodes(Arrays.asList(new Code("code10", null, "scheme10"), new Code("code11", null, "scheme11")));
         query.getCreationTime().setFrom("1980");
         query.getCreationTime().setTo("1981");
         query.getServiceStartTime().setFrom("1982");
@@ -68,12 +62,7 @@ public class FindMedicationTreatmentPlansQueryTransformerTest {
         query.setUniqueIds(Arrays.asList("uniqueId1", "uniqueId2"));
         query.setPracticeSettingCodes(Arrays.asList(new Code("code3", null, "scheme3"), new Code("code4", null, "scheme4")));
         query.setHealthcareFacilityTypeCodes(Arrays.asList(new Code("code5", null, "scheme5"), new Code("code6", null, "scheme6")));
-        var eventCodes = new QueryList<Code>();
-        eventCodes.getOuterList().add(
-                Arrays.asList(new Code("code7", null, "scheme7"), new Code("code8", null, "scheme8")));
-        eventCodes.getOuterList().add(
-                Collections.singletonList(new Code("code9", null, "scheme9")));
-        query.setEventCodes(eventCodes);
+        query.setEventCodes(Arrays.asList(new Code("code7", null, "scheme7"), new Code("code8", null, "scheme8")));
         query.setAuthorPersons(Arrays.asList("per'son1", "person2"));
 
         ebXML = new EbXMLFactory30().createAdhocQueryRequest();
@@ -87,10 +76,8 @@ public class FindMedicationTreatmentPlansQueryTransformerTest {
         assertEquals("12.21.41", ebXML.getHome());
         assertEquals(Collections.singletonList("'id1^^^&uni1&uniType1'"),
                 ebXML.getSlotValues(QueryParameter.DOC_ENTRY_PATIENT_ID.getSlotName()));
-        var confidentialitySlots = ebXML.getSlots(QueryParameter.DOC_ENTRY_CONFIDENTIALITY_CODE.getSlotName());
-        assertEquals(2, confidentialitySlots.size());
-        assertEquals(Arrays.asList("('code10^^scheme10')", "('code11^^scheme11')"), confidentialitySlots.get(0).getValueList());
-        assertEquals(Collections.singletonList("('code12^^scheme12')"), confidentialitySlots.get(1).getValueList());
+        assertEquals(Arrays.asList("('code10^^scheme10')", "('code11^^scheme11')"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_CONFIDENTIALITY_CODE.getSlotName()));
         assertEquals(Collections.singletonList("1980"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_CREATION_TIME_FROM.getSlotName()));
         assertEquals(Collections.singletonList("1981"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_CREATION_TIME_TO.getSlotName()));
         assertEquals(Collections.singletonList("1982"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_SERVICE_START_TIME_FROM.getSlotName()));
@@ -105,10 +92,8 @@ public class FindMedicationTreatmentPlansQueryTransformerTest {
                 ebXML.getSlotValues(QueryParameter.DOC_ENTRY_PRACTICE_SETTING_CODE.getSlotName()));
         assertEquals(Arrays.asList("('code5^^scheme5')", "('code6^^scheme6')"),
                 ebXML.getSlotValues(QueryParameter.DOC_ENTRY_HEALTHCARE_FACILITY_TYPE_CODE.getSlotName()));
-        var eventSlots = ebXML.getSlots(QueryParameter.DOC_ENTRY_EVENT_CODE.getSlotName());
-        assertEquals(2, eventSlots.size());
-        assertEquals(Arrays.asList("('code7^^scheme7')", "('code8^^scheme8')"), eventSlots.get(0).getValueList());
-        assertEquals(Collections.singletonList("('code9^^scheme9')"), eventSlots.get(1).getValueList());
+        assertEquals(Arrays.asList("('code7^^scheme7')", "('code8^^scheme8')"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_EVENT_CODE.getSlotName()));
         assertEquals(Arrays.asList("('per''son1')", "('person2')"),
                 ebXML.getSlotValues(QueryParameter.DOC_ENTRY_AUTHOR_PERSON.getSlotName()));
     }

--- a/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/ebxml30/FindPrescriptionsForDispenseQueryTransformerTest.java
+++ b/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/ebxml30/FindPrescriptionsForDispenseQueryTransformerTest.java
@@ -24,7 +24,6 @@ import org.openehealth.ipf.commons.ihe.xds.core.metadata.AvailabilityStatus;
 import org.openehealth.ipf.commons.ihe.xds.core.metadata.Code;
 import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
 import org.openehealth.ipf.commons.ihe.xds.core.requests.query.FindPrescriptionsForDispenseQuery;
-import org.openehealth.ipf.commons.ihe.xds.core.requests.query.QueryList;
 import org.openehealth.ipf.commons.ihe.xds.core.requests.query.QueryType;
 import org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryParameter;
 import org.openehealth.ipf.commons.ihe.xds.core.transform.requests.query.FindPrescriptionsForDispenseQueryTransformer;
@@ -51,12 +50,7 @@ public class FindPrescriptionsForDispenseQueryTransformerTest {
         query = new FindPrescriptionsForDispenseQuery();
         query.setPatientId(new Identifiable("id1", new AssigningAuthority("uni1", "uniType1")));
         query.setHomeCommunityId("12.21.41");
-        var confidentialityCodes = new QueryList<Code>();
-        confidentialityCodes.getOuterList().add(
-                Arrays.asList(new Code("code10", null, "scheme10"), new Code("code11", null, "scheme11")));
-        confidentialityCodes.getOuterList().add(
-                Collections.singletonList(new Code("code12", null, "scheme12")));
-        query.setConfidentialityCodes(confidentialityCodes);
+        query.setConfidentialityCodes(Arrays.asList(new Code("code10", null, "scheme10"), new Code("code11", null, "scheme11")));
         query.getCreationTime().setFrom("1980");
         query.getCreationTime().setTo("1981");
         query.getServiceStartTime().setFrom("1982");
@@ -68,12 +62,7 @@ public class FindPrescriptionsForDispenseQueryTransformerTest {
         query.setUniqueIds(Arrays.asList("uniqueId1", "uniqueId2"));
         query.setPracticeSettingCodes(Arrays.asList(new Code("code3", null, "scheme3"), new Code("code4", null, "scheme4")));
         query.setHealthcareFacilityTypeCodes(Arrays.asList(new Code("code5", null, "scheme5"), new Code("code6", null, "scheme6")));
-        var eventCodes = new QueryList<Code>();
-        eventCodes.getOuterList().add(
-                Arrays.asList(new Code("code7", null, "scheme7"), new Code("code8", null, "scheme8")));
-        eventCodes.getOuterList().add(
-                Collections.singletonList(new Code("code9", null, "scheme9")));
-        query.setEventCodes(eventCodes);
+        query.setEventCodes(Arrays.asList(new Code("code7", null, "scheme7"), new Code("code8", null, "scheme8")));
         query.setAuthorPersons(Arrays.asList("per'son1", "person2"));
 
         ebXML = new EbXMLFactory30().createAdhocQueryRequest();
@@ -87,10 +76,8 @@ public class FindPrescriptionsForDispenseQueryTransformerTest {
         assertEquals("12.21.41", ebXML.getHome());
         assertEquals(Collections.singletonList("'id1^^^&uni1&uniType1'"),
                 ebXML.getSlotValues(QueryParameter.DOC_ENTRY_PATIENT_ID.getSlotName()));
-        var confidentialitySlots = ebXML.getSlots(QueryParameter.DOC_ENTRY_CONFIDENTIALITY_CODE.getSlotName());
-        assertEquals(2, confidentialitySlots.size());
-        assertEquals(Arrays.asList("('code10^^scheme10')", "('code11^^scheme11')"), confidentialitySlots.get(0).getValueList());
-        assertEquals(Collections.singletonList("('code12^^scheme12')"), confidentialitySlots.get(1).getValueList());
+        assertEquals(Arrays.asList("('code10^^scheme10')", "('code11^^scheme11')"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_CONFIDENTIALITY_CODE.getSlotName()));
         assertEquals(Collections.singletonList("1980"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_CREATION_TIME_FROM.getSlotName()));
         assertEquals(Collections.singletonList("1981"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_CREATION_TIME_TO.getSlotName()));
         assertEquals(Collections.singletonList("1982"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_SERVICE_START_TIME_FROM.getSlotName()));
@@ -105,10 +92,8 @@ public class FindPrescriptionsForDispenseQueryTransformerTest {
                 ebXML.getSlotValues(QueryParameter.DOC_ENTRY_PRACTICE_SETTING_CODE.getSlotName()));
         assertEquals(Arrays.asList("('code5^^scheme5')", "('code6^^scheme6')"),
                 ebXML.getSlotValues(QueryParameter.DOC_ENTRY_HEALTHCARE_FACILITY_TYPE_CODE.getSlotName()));
-        var eventSlots = ebXML.getSlots(QueryParameter.DOC_ENTRY_EVENT_CODE.getSlotName());
-        assertEquals(2, eventSlots.size());
-        assertEquals(Arrays.asList("('code7^^scheme7')", "('code8^^scheme8')"), eventSlots.get(0).getValueList());
-        assertEquals(Collections.singletonList("('code9^^scheme9')"), eventSlots.get(1).getValueList());
+        assertEquals(Arrays.asList("('code7^^scheme7')", "('code8^^scheme8')"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_EVENT_CODE.getSlotName()));
         assertEquals(Arrays.asList("('per''son1')", "('person2')"),
                 ebXML.getSlotValues(QueryParameter.DOC_ENTRY_AUTHOR_PERSON.getSlotName()));
     }

--- a/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/ebxml30/FindPrescriptionsForValidationQueryTransformerTest.java
+++ b/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/ebxml30/FindPrescriptionsForValidationQueryTransformerTest.java
@@ -24,7 +24,6 @@ import org.openehealth.ipf.commons.ihe.xds.core.metadata.AvailabilityStatus;
 import org.openehealth.ipf.commons.ihe.xds.core.metadata.Code;
 import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
 import org.openehealth.ipf.commons.ihe.xds.core.requests.query.FindPrescriptionsForValidationQuery;
-import org.openehealth.ipf.commons.ihe.xds.core.requests.query.QueryList;
 import org.openehealth.ipf.commons.ihe.xds.core.requests.query.QueryType;
 import org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryParameter;
 import org.openehealth.ipf.commons.ihe.xds.core.transform.requests.query.FindPrescriptionsForValidationQueryTransformer;
@@ -51,12 +50,7 @@ public class FindPrescriptionsForValidationQueryTransformerTest {
         query = new FindPrescriptionsForValidationQuery();
         query.setPatientId(new Identifiable("id1", new AssigningAuthority("uni1", "uniType1")));
         query.setHomeCommunityId("12.21.41");
-        var confidentialityCodes = new QueryList<Code>();
-        confidentialityCodes.getOuterList().add(
-                Arrays.asList(new Code("code10", null, "scheme10"), new Code("code11", null, "scheme11")));
-        confidentialityCodes.getOuterList().add(
-                Collections.singletonList(new Code("code12", null, "scheme12")));
-        query.setConfidentialityCodes(confidentialityCodes);
+        query.setConfidentialityCodes(Arrays.asList(new Code("code10", null, "scheme10"), new Code("code11", null, "scheme11")));
         query.getCreationTime().setFrom("1980");
         query.getCreationTime().setTo("1981");
         query.getServiceStartTime().setFrom("1982");
@@ -68,12 +62,7 @@ public class FindPrescriptionsForValidationQueryTransformerTest {
         query.setUniqueIds(Arrays.asList("uniqueId1", "uniqueId2"));
         query.setPracticeSettingCodes(Arrays.asList(new Code("code3", null, "scheme3"), new Code("code4", null, "scheme4")));
         query.setHealthcareFacilityTypeCodes(Arrays.asList(new Code("code5", null, "scheme5"), new Code("code6", null, "scheme6")));
-        var eventCodes = new QueryList<Code>();
-        eventCodes.getOuterList().add(
-                Arrays.asList(new Code("code7", null, "scheme7"), new Code("code8", null, "scheme8")));
-        eventCodes.getOuterList().add(
-                Collections.singletonList(new Code("code9", null, "scheme9")));
-        query.setEventCodes(eventCodes);
+        query.setEventCodes(Arrays.asList(new Code("code7", null, "scheme7"), new Code("code8", null, "scheme8")));
         query.setAuthorPersons(Arrays.asList("per'son1", "person2"));
 
         ebXML = new EbXMLFactory30().createAdhocQueryRequest();
@@ -87,10 +76,8 @@ public class FindPrescriptionsForValidationQueryTransformerTest {
         assertEquals("12.21.41", ebXML.getHome());
         assertEquals(Collections.singletonList("'id1^^^&uni1&uniType1'"),
                 ebXML.getSlotValues(QueryParameter.DOC_ENTRY_PATIENT_ID.getSlotName()));
-        var confidentialitySlots = ebXML.getSlots(QueryParameter.DOC_ENTRY_CONFIDENTIALITY_CODE.getSlotName());
-        assertEquals(2, confidentialitySlots.size());
-        assertEquals(Arrays.asList("('code10^^scheme10')", "('code11^^scheme11')"), confidentialitySlots.get(0).getValueList());
-        assertEquals(Collections.singletonList("('code12^^scheme12')"), confidentialitySlots.get(1).getValueList());
+        assertEquals(Arrays.asList("('code10^^scheme10')", "('code11^^scheme11')"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_CONFIDENTIALITY_CODE.getSlotName()));
         assertEquals(Collections.singletonList("1980"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_CREATION_TIME_FROM.getSlotName()));
         assertEquals(Collections.singletonList("1981"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_CREATION_TIME_TO.getSlotName()));
         assertEquals(Collections.singletonList("1982"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_SERVICE_START_TIME_FROM.getSlotName()));
@@ -105,10 +92,8 @@ public class FindPrescriptionsForValidationQueryTransformerTest {
                 ebXML.getSlotValues(QueryParameter.DOC_ENTRY_PRACTICE_SETTING_CODE.getSlotName()));
         assertEquals(Arrays.asList("('code5^^scheme5')", "('code6^^scheme6')"),
                 ebXML.getSlotValues(QueryParameter.DOC_ENTRY_HEALTHCARE_FACILITY_TYPE_CODE.getSlotName()));
-        var eventSlots = ebXML.getSlots(QueryParameter.DOC_ENTRY_EVENT_CODE.getSlotName());
-        assertEquals(2, eventSlots.size());
-        assertEquals(Arrays.asList("('code7^^scheme7')", "('code8^^scheme8')"), eventSlots.get(0).getValueList());
-        assertEquals(Collections.singletonList("('code9^^scheme9')"), eventSlots.get(1).getValueList());
+        assertEquals(Arrays.asList("('code7^^scheme7')", "('code8^^scheme8')"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_EVENT_CODE.getSlotName()));
         assertEquals(Arrays.asList("('per''son1')", "('person2')"),
                 ebXML.getSlotValues(QueryParameter.DOC_ENTRY_AUTHOR_PERSON.getSlotName()));
     }

--- a/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/ebxml30/FindPrescriptionsQueryTransformerTest.java
+++ b/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/core/transform/requests/ebxml30/FindPrescriptionsQueryTransformerTest.java
@@ -24,7 +24,6 @@ import org.openehealth.ipf.commons.ihe.xds.core.metadata.AvailabilityStatus;
 import org.openehealth.ipf.commons.ihe.xds.core.metadata.Code;
 import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
 import org.openehealth.ipf.commons.ihe.xds.core.requests.query.FindPrescriptionsQuery;
-import org.openehealth.ipf.commons.ihe.xds.core.requests.query.QueryList;
 import org.openehealth.ipf.commons.ihe.xds.core.requests.query.QueryType;
 import org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryParameter;
 import org.openehealth.ipf.commons.ihe.xds.core.transform.requests.query.FindPrescriptionsQueryTransformer;
@@ -51,12 +50,7 @@ public class FindPrescriptionsQueryTransformerTest {
         query = new FindPrescriptionsQuery();
         query.setPatientId(new Identifiable("id1", new AssigningAuthority("uni1", "uniType1")));
         query.setHomeCommunityId("12.21.41");
-        var confidentialityCodes = new QueryList<Code>();
-        confidentialityCodes.getOuterList().add(
-                Arrays.asList(new Code("code10", null, "scheme10"), new Code("code11", null, "scheme11")));
-        confidentialityCodes.getOuterList().add(
-                Collections.singletonList(new Code("code12", null, "scheme12")));
-        query.setConfidentialityCodes(confidentialityCodes);
+        query.setConfidentialityCodes(Arrays.asList(new Code("code10", null, "scheme10"), new Code("code11", null, "scheme11")));
         query.getCreationTime().setFrom("1980");
         query.getCreationTime().setTo("1981");
         query.getServiceStartTime().setFrom("1982");
@@ -68,12 +62,7 @@ public class FindPrescriptionsQueryTransformerTest {
         query.setUniqueIds(Arrays.asList("uniqueId1", "uniqueId2"));
         query.setPracticeSettingCodes(Arrays.asList(new Code("code3", null, "scheme3"), new Code("code4", null, "scheme4")));
         query.setHealthcareFacilityTypeCodes(Arrays.asList(new Code("code5", null, "scheme5"), new Code("code6", null, "scheme6")));
-        var eventCodes = new QueryList<Code>();
-        eventCodes.getOuterList().add(
-                Arrays.asList(new Code("code7", null, "scheme7"), new Code("code8", null, "scheme8")));
-        eventCodes.getOuterList().add(
-                Collections.singletonList(new Code("code9", null, "scheme9")));
-        query.setEventCodes(eventCodes);
+        query.setEventCodes(Arrays.asList(new Code("code7", null, "scheme7"), new Code("code8", null, "scheme8")));
         query.setAuthorPersons(Arrays.asList("per'son1", "person2"));
 
         ebXML = new EbXMLFactory30().createAdhocQueryRequest();
@@ -87,10 +76,8 @@ public class FindPrescriptionsQueryTransformerTest {
         assertEquals("12.21.41", ebXML.getHome());
         assertEquals(Collections.singletonList("'id1^^^&uni1&uniType1'"),
                 ebXML.getSlotValues(QueryParameter.DOC_ENTRY_PATIENT_ID.getSlotName()));
-        var confidentialitySlots = ebXML.getSlots(QueryParameter.DOC_ENTRY_CONFIDENTIALITY_CODE.getSlotName());
-        assertEquals(2, confidentialitySlots.size());
-        assertEquals(Arrays.asList("('code10^^scheme10')", "('code11^^scheme11')"), confidentialitySlots.get(0).getValueList());
-        assertEquals(Collections.singletonList("('code12^^scheme12')"), confidentialitySlots.get(1).getValueList());
+        assertEquals(Arrays.asList("('code10^^scheme10')", "('code11^^scheme11')"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_CONFIDENTIALITY_CODE.getSlotName()));
         assertEquals(Collections.singletonList("1980"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_CREATION_TIME_FROM.getSlotName()));
         assertEquals(Collections.singletonList("1981"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_CREATION_TIME_TO.getSlotName()));
         assertEquals(Collections.singletonList("1982"), ebXML.getSlotValues(QueryParameter.DOC_ENTRY_SERVICE_START_TIME_FROM.getSlotName()));
@@ -105,10 +92,8 @@ public class FindPrescriptionsQueryTransformerTest {
                 ebXML.getSlotValues(QueryParameter.DOC_ENTRY_PRACTICE_SETTING_CODE.getSlotName()));
         assertEquals(Arrays.asList("('code5^^scheme5')", "('code6^^scheme6')"),
                 ebXML.getSlotValues(QueryParameter.DOC_ENTRY_HEALTHCARE_FACILITY_TYPE_CODE.getSlotName()));
-        var eventSlots = ebXML.getSlots(QueryParameter.DOC_ENTRY_EVENT_CODE.getSlotName());
-        assertEquals(2, eventSlots.size());
-        assertEquals(Arrays.asList("('code7^^scheme7')", "('code8^^scheme8')"), eventSlots.get(0).getValueList());
-        assertEquals(Collections.singletonList("('code9^^scheme9')"), eventSlots.get(1).getValueList());
+        assertEquals(Arrays.asList("('code7^^scheme7')", "('code8^^scheme8')"),
+                ebXML.getSlotValues(QueryParameter.DOC_ENTRY_EVENT_CODE.getSlotName()));
         assertEquals(Arrays.asList("('per''son1')", "('person2')"),
                 ebXML.getSlotValues(QueryParameter.DOC_ENTRY_AUTHOR_PERSON.getSlotName()));
     }


### PR DESCRIPTION
This PR fixes three issues with PHARM-1.

1. The validation of the _$XDSDocumentEntryFormatCode_ parameter in the FindMedicationList query was using the QueryListCodeValidation instead of the CodeValidation (the parameter is a simple list, not a QueryList).
2. In queries other than FindMedicationList, the parameters _$XDSDocumentEntryEventCodeList_ and _$XDSDocumentEntryConfidentialityCode_ are simple lists, not QueryLists. The specification references _ITI TF-2a: 3.18.4.1.2.3.4 Coding of Code/Code-Scheme_ for the coding and not _3.18.4.1.2.3.5 Coding of Single/Multiple Values_.
3. In queries other than FindMedicationList, the parameters _$XDSDocumentEntryEntryUUID_ and _$XDSDocumentEntryUniqueId_ are a non-required choice. The specification says only PatientID and Status are the required parameters, it should be allowed to specify neither of the parameters. I've added an 'optional' flag to the ChoiceValidator to enable/disable the check for missing required parameter. Another solution is to split it into OptionalChoiceValidator and RequiredChoiceValidator, but that would duplicate code.