### PR TITLE
WIP: In MHD ITI-66/67 transactions, the search parameter 'status' is required

### DIFF
--- a/commons/ihe/fhir/r4/mhd/src/main/java/org/openehealth/ipf/commons/ihe/fhir/iti66/Iti66ResourceProvider.java
+++ b/commons/ihe/fhir/r4/mhd/src/main/java/org/openehealth/ipf/commons/ihe/fhir/iti66/Iti66ResourceProvider.java
@@ -48,7 +48,7 @@ public class Iti66ResourceProvider extends AbstractPlainProvider {
             @OptionalParam(name = DocumentManifest.SP_IDENTIFIER) TokenParam identifier,
             @OptionalParam(name = DocumentManifest.SP_TYPE) TokenOrListParam type,
             @OptionalParam(name = DocumentManifest.SP_SOURCE) TokenOrListParam source,
-            @OptionalParam(name = DocumentManifest.SP_STATUS) TokenOrListParam status,
+            @RequiredParam(name = DocumentManifest.SP_STATUS) TokenOrListParam status,
             // Extension to ITI-66
             @OptionalParam(name = IAnyResource.SP_RES_ID) TokenParam resourceId,
             @Sort SortSpec sortSpec,

--- a/commons/ihe/fhir/r4/mhd/src/main/java/org/openehealth/ipf/commons/ihe/fhir/iti67/Iti67ResourceProvider.java
+++ b/commons/ihe/fhir/r4/mhd/src/main/java/org/openehealth/ipf/commons/ihe/fhir/iti67/Iti67ResourceProvider.java
@@ -73,7 +73,7 @@ public class Iti67ResourceProvider extends AbstractPlainProvider {
     @Search(type = DocumentReference.class)
     public IBundleProvider documentReferenceSearch(
             @RequiredParam(name = DocumentReference.SP_PATIENT, chainWhitelist = {"", Patient.SP_IDENTIFIER}) ReferenceParam patient,
-            @OptionalParam(name = DocumentReference.SP_STATUS) TokenOrListParam status,
+            @RequiredParam(name = DocumentReference.SP_STATUS) TokenOrListParam status,
             @OptionalParam(name = DocumentReference.SP_IDENTIFIER) TokenParam identifier,
             @OptionalParam(name = DocumentReference.SP_DATE) DateRangeParam date,
             @OptionalParam(name = STU3_INDEXED) DateRangeParam indexed,

--- a/commons/ihe/fhir/stu3/mhd/src/main/java/org/openehealth/ipf/commons/ihe/fhir/iti66/Iti66ResourceProvider.java
+++ b/commons/ihe/fhir/stu3/mhd/src/main/java/org/openehealth/ipf/commons/ihe/fhir/iti66/Iti66ResourceProvider.java
@@ -47,7 +47,7 @@ public class Iti66ResourceProvider extends AbstractPlainProvider {
             @OptionalParam(name = DocumentManifest.SP_AUTHOR, chainWhitelist = { Practitioner.SP_FAMILY, Practitioner.SP_GIVEN }) ReferenceAndListParam author,
             @OptionalParam(name = DocumentManifest.SP_TYPE) TokenOrListParam type,
             @OptionalParam(name = DocumentManifest.SP_SOURCE) TokenOrListParam source,
-            @OptionalParam(name = DocumentManifest.SP_STATUS) TokenOrListParam status,
+            @RequiredParam(name = DocumentManifest.SP_STATUS) TokenOrListParam status,
             // Extension to ITI-66
             @OptionalParam(name = IAnyResource.SP_RES_ID) TokenParam resourceId,
             @Sort SortSpec sortSpec,

--- a/commons/ihe/fhir/stu3/mhd/src/main/java/org/openehealth/ipf/commons/ihe/fhir/iti67/Iti67ResourceProvider.java
+++ b/commons/ihe/fhir/stu3/mhd/src/main/java/org/openehealth/ipf/commons/ihe/fhir/iti67/Iti67ResourceProvider.java
@@ -53,7 +53,7 @@ public class Iti67ResourceProvider extends AbstractPlainProvider {
     @Search(type = DocumentReference.class)
     public IBundleProvider documentReferenceSearch(
             @RequiredParam(name = DocumentReference.SP_PATIENT, chainWhitelist = {"", Patient.SP_IDENTIFIER}) ReferenceParam patient,
-            @OptionalParam(name = DocumentReference.SP_STATUS) TokenOrListParam status,
+            @RequiredParam(name = DocumentReference.SP_STATUS) TokenOrListParam status,
             @OptionalParam(name = DocumentReference.SP_INDEXED) DateRangeParam indexed,
             @OptionalParam(name = DocumentReference.SP_AUTHOR, chainWhitelist = { Practitioner.SP_FAMILY, Practitioner.SP_GIVEN }) ReferenceAndListParam author,
             @OptionalParam(name = DocumentReference.SP_CLASS) TokenOrListParam class_,

--- a/platform-camel/ihe/fhir/r4/mhd/src/test/java/org/openehealth/ipf/platform/camel/ihe/fhir/iti66/AbstractTestIti66.java
+++ b/platform-camel/ihe/fhir/r4/mhd/src/test/java/org/openehealth/ipf/platform/camel/ihe/fhir/iti66/AbstractTestIti66.java
@@ -49,6 +49,7 @@ abstract class AbstractTestIti66 extends FhirTestContainer {
         return client.search()
                 .forResource(DocumentManifest.class)
                 .where(requestData)
+                .where(new TokenClientParam("status").exactly().code("current"))
                 .returnBundle(Bundle.class)
                 .encodedXml()
                 .execute();

--- a/platform-camel/ihe/fhir/r4/mhd/src/test/java/org/openehealth/ipf/platform/camel/ihe/fhir/iti66/TestIti66Success.java
+++ b/platform-camel/ihe/fhir/r4/mhd/src/test/java/org/openehealth/ipf/platform/camel/ihe/fhir/iti66/TestIti66Success.java
@@ -102,7 +102,7 @@ public class TestIti66Success extends AbstractTestIti66 {
         var query = event.getParticipantObjectIdentifications().get(1);
         assertEquals(ParticipantObjectTypeCode.System, query.getParticipantObjectTypeCode());
         assertEquals(ParticipantObjectTypeCodeRole.Query, query.getParticipantObjectTypeCodeRole());
-        assertEquals("http://localhost:8999/DocumentManifest?patient.identifier=urn:oid:2.16.840.1.113883.3.37.4.1.1.2.1.1|1&_format=xml",
+        assertEquals("http://localhost:8999/DocumentManifest?patient.identifier=urn:oid:2.16.840.1.113883.3.37.4.1.1.2.1.1|1&status=current&_format=xml",
                 new String(query.getParticipantObjectQuery(), StandardCharsets.UTF_8));
 
         assertEquals(FhirParticipantObjectIdTypeCode.MobileDocumentManifestQuery, query.getParticipantObjectIDTypeCode());

--- a/platform-camel/ihe/fhir/r4/mhd/src/test/java/org/openehealth/ipf/platform/camel/ihe/fhir/iti67/AbstractTestIti67.java
+++ b/platform-camel/ihe/fhir/r4/mhd/src/test/java/org/openehealth/ipf/platform/camel/ihe/fhir/iti67/AbstractTestIti67.java
@@ -50,6 +50,7 @@ abstract class AbstractTestIti67 extends FhirTestContainer {
         return client.search()
                 .forResource(DocumentReference.class)
                 .where(requestData)
+                .where(new TokenClientParam("status").exactly().code("current"))
                 .returnBundle(Bundle.class)
                 .encodedXml()
                 .execute();

--- a/platform-camel/ihe/fhir/r4/mhd/src/test/java/org/openehealth/ipf/platform/camel/ihe/fhir/iti67/TestIti67Success.java
+++ b/platform-camel/ihe/fhir/r4/mhd/src/test/java/org/openehealth/ipf/platform/camel/ihe/fhir/iti67/TestIti67Success.java
@@ -103,7 +103,7 @@ public class TestIti67Success extends AbstractTestIti67 {
         var query = event.getParticipantObjectIdentifications().get(1);
         assertEquals(ParticipantObjectTypeCode.System, query.getParticipantObjectTypeCode());
         assertEquals(ParticipantObjectTypeCodeRole.Query, query.getParticipantObjectTypeCodeRole());
-        assertEquals("http://localhost:8999/DocumentReference?patient.identifier=urn:oid:2.16.840.1.113883.3.37.4.1.1.2.1.1|1&_format=xml",
+        assertEquals("http://localhost:8999/DocumentReference?patient.identifier=urn:oid:2.16.840.1.113883.3.37.4.1.1.2.1.1|1&status=current&_format=xml",
                 new String(query.getParticipantObjectQuery(), StandardCharsets.UTF_8));
 
         assertEquals(FhirParticipantObjectIdTypeCode.MobileDocumentReferenceQuery, query.getParticipantObjectIDTypeCode());

--- a/platform-camel/ihe/fhir/stu3/mhd/src/test/java/org/openehealth/ipf/platform/camel/ihe/fhir/iti66/AbstractTestIti66.java
+++ b/platform-camel/ihe/fhir/stu3/mhd/src/test/java/org/openehealth/ipf/platform/camel/ihe/fhir/iti66/AbstractTestIti66.java
@@ -49,6 +49,7 @@ abstract class AbstractTestIti66 extends FhirTestContainer {
         return client.search()
                 .forResource(DocumentManifest.class)
                 .where(requestData)
+                .where(new TokenClientParam("status").exactly().code("current"))
                 .returnBundle(Bundle.class)
                 .encodedXml()
                 .execute();

--- a/platform-camel/ihe/fhir/stu3/mhd/src/test/java/org/openehealth/ipf/platform/camel/ihe/fhir/iti66/TestIti66Success.java
+++ b/platform-camel/ihe/fhir/stu3/mhd/src/test/java/org/openehealth/ipf/platform/camel/ihe/fhir/iti66/TestIti66Success.java
@@ -102,7 +102,7 @@ public class TestIti66Success extends AbstractTestIti66 {
         var query = event.getParticipantObjectIdentifications().get(1);
         assertEquals(ParticipantObjectTypeCode.System, query.getParticipantObjectTypeCode());
         assertEquals(ParticipantObjectTypeCodeRole.Query, query.getParticipantObjectTypeCodeRole());
-        assertEquals("http://localhost:8999/DocumentManifest?patient.identifier=urn:oid:2.16.840.1.113883.3.37.4.1.1.2.1.1|1&_format=xml",
+        assertEquals("http://localhost:8999/DocumentManifest?patient.identifier=urn:oid:2.16.840.1.113883.3.37.4.1.1.2.1.1|1&status=current&_format=xml",
                 new String(query.getParticipantObjectQuery(), StandardCharsets.UTF_8));
 
         assertEquals(FhirParticipantObjectIdTypeCode.MobileDocumentManifestQuery, query.getParticipantObjectIDTypeCode());

--- a/platform-camel/ihe/fhir/stu3/mhd/src/test/java/org/openehealth/ipf/platform/camel/ihe/fhir/iti67/AbstractTestIti67.java
+++ b/platform-camel/ihe/fhir/stu3/mhd/src/test/java/org/openehealth/ipf/platform/camel/ihe/fhir/iti67/AbstractTestIti67.java
@@ -50,6 +50,7 @@ abstract class AbstractTestIti67 extends FhirTestContainer {
         return client.search()
                 .forResource(DocumentReference.class)
                 .where(requestData)
+                .where(new TokenClientParam("status").exactly().code("current"))
                 .returnBundle(Bundle.class)
                 .encodedXml()
                 .execute();

--- a/platform-camel/ihe/fhir/stu3/mhd/src/test/java/org/openehealth/ipf/platform/camel/ihe/fhir/iti67/TestIti67Success.java
+++ b/platform-camel/ihe/fhir/stu3/mhd/src/test/java/org/openehealth/ipf/platform/camel/ihe/fhir/iti67/TestIti67Success.java
@@ -104,7 +104,7 @@ public class TestIti67Success extends AbstractTestIti67 {
         var query = event.getParticipantObjectIdentifications().get(1);
         assertEquals(ParticipantObjectTypeCode.System, query.getParticipantObjectTypeCode());
         assertEquals(ParticipantObjectTypeCodeRole.Query, query.getParticipantObjectTypeCodeRole());
-        assertEquals("http://localhost:8999/DocumentReference?patient.identifier=urn:oid:2.16.840.1.113883.3.37.4.1.1.2.1.1|1&_format=xml",
+        assertEquals("http://localhost:8999/DocumentReference?patient.identifier=urn:oid:2.16.840.1.113883.3.37.4.1.1.2.1.1|1&status=current&_format=xml",
                 new String(query.getParticipantObjectQuery(), StandardCharsets.UTF_8));
 
         assertEquals(FhirParticipantObjectIdTypeCode.MobileDocumentReferenceQuery, query.getParticipantObjectIDTypeCode());


### PR DESCRIPTION
It was changed between revisions 2.2 and 2.3 and now reads (for both transactions):

> The Document Consumer shall include search parameter `patient` or `patient.identifier`, and `status`. The other parameters described below are optional.

Revision 2.3 targets FHIR STU3, so I've updated both files.

WIP: Need to fix tests.