### PR TITLE
#326 Fix ITI-43 server audit message

### DIFF
--- a/commons/ihe/core/src/main/java/org/openehealth/ipf/commons/ihe/core/atna/event/IHEAuditMessageBuilder.java
+++ b/commons/ihe/core/src/main/java/org/openehealth/ipf/commons/ihe/core/atna/event/IHEAuditMessageBuilder.java
@@ -106,7 +106,7 @@ public abstract class IHEAuditMessageBuilder<T extends IHEAuditMessageBuilder<T,
                     auditDataset.getSourceUserId() != null ?
                             auditDataset.getSourceUserId() :
                             auditContext.getAuditValueIfMissing(),
-                    getRemoteAltUserId(),
+                    null,
                     auditDataset.getSourceUserName(),
                     getHostFromUrl(auditDataset.getRemoteAddress()),
                     auditDataset.isSourceUserIsRequestor());
@@ -115,19 +115,11 @@ public abstract class IHEAuditMessageBuilder<T extends IHEAuditMessageBuilder<T,
                     auditDataset.getDestinationUserId() != null ?
                             auditDataset.getDestinationUserId() :
                             auditContext.getAuditValueIfMissing(),
-                    getRemoteAltUserId(),
+                    null,
                     null,
                     getHostFromUrl(auditDataset.getRemoteAddress()),
                     auditDataset.isDestinationUserIsRequestor());
         return self();
-    }
-
-    /**
-     * @return the remote AltUserId. Usually null, except for ITI-43 where there is
-     * an error in the spec; the value is inserted by Iti43ServerAuditStrategy.
-     */
-    protected String getRemoteAltUserId() {
-        return null;
     }
 
     protected final T addHumanRequestor(AuditDataset auditDataset) {

--- a/commons/ihe/core/src/main/java/org/openehealth/ipf/commons/ihe/core/atna/event/IHEAuditMessageBuilder.java
+++ b/commons/ihe/core/src/main/java/org/openehealth/ipf/commons/ihe/core/atna/event/IHEAuditMessageBuilder.java
@@ -124,7 +124,7 @@ public abstract class IHEAuditMessageBuilder<T extends IHEAuditMessageBuilder<T,
 
     /**
      * @return the remote AltUserId. Usually null, except for ITI-43 where there is
-     * an error in the spec
+     * an error in the spec; the value is inserted by Iti43ServerAuditStrategy.
      */
     protected String getRemoteAltUserId() {
         return null;

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/audit/XdsRetrieveAuditStrategy30.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/audit/XdsRetrieveAuditStrategy30.java
@@ -16,8 +16,8 @@
 package org.openehealth.ipf.commons.ihe.xds.core.audit;
 
 import org.openehealth.ipf.commons.audit.AuditContext;
-import org.openehealth.ipf.commons.ihe.xds.core.ebxml.ebxml30.RetrieveDocumentSetResponseType;
 import org.openehealth.ipf.commons.ihe.xds.core.audit.XdsNonconstructiveDocumentSetRequestAuditDataset.Status;
+import org.openehealth.ipf.commons.ihe.xds.core.ebxml.ebxml30.RetrieveDocumentSetResponseType;
 
 /**
  * Basis for Strategy pattern implementation for ATNA Auditing
@@ -28,7 +28,9 @@ import org.openehealth.ipf.commons.ihe.xds.core.audit.XdsNonconstructiveDocument
 public abstract class XdsRetrieveAuditStrategy30 extends XdsNonconstructiveDocumentSetRequestAuditStrategy30 {
 
     public XdsRetrieveAuditStrategy30(boolean serverSide) {
-        super(serverSide);
+        // These transactions define source and destination in reverse direction, so we need to 
+        // toggle server side indicator
+        super(!serverSide);
     }
 
     /**
@@ -40,8 +42,6 @@ public abstract class XdsRetrieveAuditStrategy30 extends XdsNonconstructiveDocum
     @Override
     public XdsNonconstructiveDocumentSetRequestAuditDataset createAuditDataset() {
         var auditDataset = super.createAuditDataset();
-        // This is also an error in the spec.
-        auditDataset.setSourceUserIsRequestor(false);
         return auditDataset;
     }
 
@@ -59,11 +59,6 @@ public abstract class XdsRetrieveAuditStrategy30 extends XdsNonconstructiveDocum
             }
         }
 
-        // These transactions define source and destination userID the inverted way. This could be a
-        // specification mistake.
-        var sourceUserId = auditDataset.getSourceUserId();
-        auditDataset.setSourceUserId(auditDataset.getDestinationUserId());
-        auditDataset.setDestinationUserId(sourceUserId);
         return true;
     }
 

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/audit/XdsRetrieveAuditStrategy30.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/audit/XdsRetrieveAuditStrategy30.java
@@ -42,6 +42,8 @@ public abstract class XdsRetrieveAuditStrategy30 extends XdsNonconstructiveDocum
     @Override
     public XdsNonconstructiveDocumentSetRequestAuditDataset createAuditDataset() {
         var auditDataset = super.createAuditDataset();
+        // This is also an error in the spec.
+        auditDataset.setSourceUserIsRequestor(false);
         return auditDataset;
     }
 
@@ -59,6 +61,11 @@ public abstract class XdsRetrieveAuditStrategy30 extends XdsNonconstructiveDocum
             }
         }
 
+        // These transactions define source and destination userID the inverted way. This could be a
+        // specification mistake.
+        var sourceUserId = auditDataset.getSourceUserId();
+        auditDataset.setSourceUserId(auditDataset.getDestinationUserId());
+        auditDataset.setDestinationUserId(sourceUserId);
         return true;
     }
 

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/audit/event/XdsPHIImportBuilder.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/audit/event/XdsPHIImportBuilder.java
@@ -98,12 +98,4 @@ public class XdsPHIImportBuilder extends PHIImportBuilder<XdsPHIImportBuilder> {
                                 studyInstanceIds[i], xcaHomeCommunityId)));
         return self();
     }
-
-    /**
-     * @return "missing". ITI-43 makes the remote alt user ID mandatory and so does the EVS validator
-     */
-    @Override
-    protected String getRemoteAltUserId() {
-        return getAuditContext().getAuditValueIfMissing();
-    }
 }

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/iti43/Iti43ServerAuditStrategy.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/iti43/Iti43ServerAuditStrategy.java
@@ -18,9 +18,9 @@ package org.openehealth.ipf.commons.ihe.xds.iti43;
 import org.openehealth.ipf.commons.audit.AuditContext;
 import org.openehealth.ipf.commons.audit.codes.EventActionCode;
 import org.openehealth.ipf.commons.audit.model.AuditMessage;
-import org.openehealth.ipf.commons.audit.utils.AuditUtils;
-import org.openehealth.ipf.commons.ihe.xds.core.audit.*;
+import org.openehealth.ipf.commons.ihe.xds.core.audit.XdsNonconstructiveDocumentSetRequestAuditDataset;
 import org.openehealth.ipf.commons.ihe.xds.core.audit.XdsNonconstructiveDocumentSetRequestAuditDataset.Status;
+import org.openehealth.ipf.commons.ihe.xds.core.audit.XdsRetrieveAuditStrategy30;
 import org.openehealth.ipf.commons.ihe.xds.core.audit.codes.XdsEventTypeCode;
 import org.openehealth.ipf.commons.ihe.xds.core.audit.event.XdsPHIExportBuilder;
 
@@ -42,13 +42,7 @@ public class Iti43ServerAuditStrategy extends XdsRetrieveAuditStrategy30 {
     public AuditMessage[] makeAuditMessage(AuditContext auditContext, XdsNonconstructiveDocumentSetRequestAuditDataset auditDataset) {
         return Stream.of(Status.values())
                 .filter(auditDataset::hasDocuments)
-                .map((Status s) -> {
-                    final var auditMessage = doMakeAuditMessage(auditContext, auditDataset, s);
-                    // Fix the @AlternativeUserID (the process ID) that shall go into the source, not the destination
-                    auditMessage.getActiveParticipants().get(0).setAlternativeUserID(AuditUtils.getProcessId());
-                    auditMessage.getActiveParticipants().get(1).setAlternativeUserID(null);
-                    return auditMessage;
-                })
+                .map(s -> doMakeAuditMessage(auditContext, auditDataset, s))
                 .toArray(AuditMessage[]::new);
     }
 

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/iti43/Iti43ServerAuditStrategy.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/iti43/Iti43ServerAuditStrategy.java
@@ -18,6 +18,7 @@ package org.openehealth.ipf.commons.ihe.xds.iti43;
 import org.openehealth.ipf.commons.audit.AuditContext;
 import org.openehealth.ipf.commons.audit.codes.EventActionCode;
 import org.openehealth.ipf.commons.audit.model.AuditMessage;
+import org.openehealth.ipf.commons.audit.utils.AuditUtils;
 import org.openehealth.ipf.commons.ihe.xds.core.audit.*;
 import org.openehealth.ipf.commons.ihe.xds.core.audit.XdsNonconstructiveDocumentSetRequestAuditDataset.Status;
 import org.openehealth.ipf.commons.ihe.xds.core.audit.codes.XdsEventTypeCode;
@@ -41,7 +42,13 @@ public class Iti43ServerAuditStrategy extends XdsRetrieveAuditStrategy30 {
     public AuditMessage[] makeAuditMessage(AuditContext auditContext, XdsNonconstructiveDocumentSetRequestAuditDataset auditDataset) {
         return Stream.of(Status.values())
                 .filter(auditDataset::hasDocuments)
-                .map(s -> doMakeAuditMessage(auditContext, auditDataset, s))
+                .map((Status s) -> {
+                    final var auditMessage = doMakeAuditMessage(auditContext, auditDataset, s);
+                    // Fix the @AlternativeUserID (the process ID) that shall go into the source, not the destination
+                    auditMessage.getActiveParticipants().get(0).setAlternativeUserID(AuditUtils.getProcessId());
+                    auditMessage.getActiveParticipants().get(1).setAlternativeUserID(null);
+                    return auditMessage;
+                })
                 .toArray(AuditMessage[]::new);
     }
 

--- a/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/iti43/Iti43AuditStrategyTest.java
+++ b/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/iti43/Iti43AuditStrategyTest.java
@@ -1,81 +1,62 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- */
-
-package org.openehealth.ipf.commons.ihe.xds.rad69;
+package org.openehealth.ipf.commons.ihe.xds.iti43;
 
 import org.junit.Test;
 import org.openehealth.ipf.commons.audit.codes.EventActionCode;
 import org.openehealth.ipf.commons.audit.codes.EventIdCode;
 import org.openehealth.ipf.commons.audit.codes.EventOutcomeIndicator;
-import org.openehealth.ipf.commons.audit.codes.ParticipantObjectTypeCode;
 import org.openehealth.ipf.commons.audit.codes.ParticipantObjectTypeCodeRole;
+import org.openehealth.ipf.commons.audit.model.AuditMessage;
 import org.openehealth.ipf.commons.ihe.core.atna.AuditDataset.HumanUser;
 import org.openehealth.ipf.commons.ihe.xds.atna.XdsAuditorTestBase;
-import org.openehealth.ipf.commons.ihe.xds.core.audit.XdsIRetrieveAuditStrategy30;
 import org.openehealth.ipf.commons.ihe.xds.core.audit.XdsNonconstructiveDocumentSetRequestAuditDataset;
+import org.openehealth.ipf.commons.ihe.xds.core.audit.XdsRetrieveAuditStrategy30;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-/**
- * @author Christian Ohr
- */
-public class Rad69AuditStrategyTest extends XdsAuditorTestBase {
-
+public class Iti43AuditStrategyTest extends XdsAuditorTestBase  {
     @Test
-    public void testServerSide() {
-        testRequest(true, new Rad69ServerAuditStrategy());
+    public void testDocumentRepositoryAudit() {
+        var auditMessage = testRequest(new Iti43ServerAuditStrategy());
+        assertCommonXdsAuditAttributes(auditMessage,
+                EventOutcomeIndicator.Success,
+                EventIdCode.Export,
+                EventActionCode.Read,
+                false,
+                true);
     }
 
     @Test
-    public void testClientSide() {
-        testRequest(false, new Rad69ClientAuditStrategy());
+    public void testConsumerAudit() {
+        var auditMessage = testRequest(new Iti43ClientAuditStrategy());
+        assertCommonXdsAuditAttributes(auditMessage,
+                EventOutcomeIndicator.Success,
+                EventIdCode.Import,
+                EventActionCode.Create,
+                true,
+                true);
     }
 
-    private void testRequest(boolean serverSide, XdsIRetrieveAuditStrategy30 strategy) {
+    private AuditMessage testRequest(XdsRetrieveAuditStrategy30 strategy) {
         var auditDataset = getXdsAuditDataset(strategy);
         var auditMessage = makeAuditMessage(strategy, auditContext, auditDataset);
 
         assertNotNull(auditMessage);
         auditMessage.validate();
-
-        // System.out.println(printAuditMessage(auditMessage));
-
-        assertCommonXdsAuditAttributes(auditMessage,
-                EventOutcomeIndicator.Success,
-                serverSide ? EventIdCode.DICOMInstancesTransferred : EventIdCode.DICOMInstancesAccessed,
-                serverSide ? EventActionCode.Read : EventActionCode.Create,
-                !serverSide,
-                true);
+        
 
         assertEquals(3, auditMessage.findParticipantObjectIdentifications(
                 poit -> poit.getParticipantObjectTypeCodeRole() == ParticipantObjectTypeCodeRole.Report).size());
-
-        assertEquals(4, auditMessage.findParticipantObjectIdentifications(
-                poit -> poit.getParticipantObjectTypeCode() == ParticipantObjectTypeCode.System)
-                .get(0)
-                .getParticipantObjectDetails().size());
-
+        
+        return auditMessage;
     }
 
-    private XdsNonconstructiveDocumentSetRequestAuditDataset getXdsAuditDataset(XdsIRetrieveAuditStrategy30 strategy) {
+    private XdsNonconstructiveDocumentSetRequestAuditDataset getXdsAuditDataset(XdsRetrieveAuditStrategy30 strategy) {
         var auditDataset = strategy.createAuditDataset();
         auditDataset.setEventOutcomeIndicator(EventOutcomeIndicator.Success);
         // auditDataset.setLocalAddress(SERVER_URI);
         auditDataset.setRemoteAddress(CLIENT_IP_ADDRESS);
+        auditDataset.setSourceUserName("");
         auditDataset.setSourceUserId(REPLY_TO_URI);
         auditDataset.setDestinationUserId(SERVER_URI);
         auditDataset.setRequestPayload(QUERY_PAYLOAD);
@@ -89,8 +70,8 @@ public class Rad69AuditStrategyTest extends XdsAuditorTestBase {
                             DOCUMENT_OIDS[i],
                             REPOSITORY_OIDS[i],
                             HOME_COMMUNITY_IDS[i],
-                            STUDY_INSTANCE_UUIDS[i],
-                            SERIES_INSTANCE_UUIDS[i],
+                            null,
+                            null,
                             XdsNonconstructiveDocumentSetRequestAuditDataset.Status.SUCCESSFUL));
         }
         return auditDataset;

--- a/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/rad75/Rad75AuditStrategyTest.java
+++ b/commons/ihe/xds/src/test/java/org/openehealth/ipf/commons/ihe/xds/rad75/Rad75AuditStrategyTest.java
@@ -17,7 +17,11 @@
 package org.openehealth.ipf.commons.ihe.xds.rad75;
 
 import org.junit.Test;
-import org.openehealth.ipf.commons.audit.codes.*;
+import org.openehealth.ipf.commons.audit.codes.EventActionCode;
+import org.openehealth.ipf.commons.audit.codes.EventIdCode;
+import org.openehealth.ipf.commons.audit.codes.EventOutcomeIndicator;
+import org.openehealth.ipf.commons.audit.codes.ParticipantObjectTypeCode;
+import org.openehealth.ipf.commons.audit.codes.ParticipantObjectTypeCodeRole;
 import org.openehealth.ipf.commons.ihe.core.atna.AuditDataset.HumanUser;
 import org.openehealth.ipf.commons.ihe.xds.atna.XdsAuditorTestBase;
 import org.openehealth.ipf.commons.ihe.xds.core.audit.XdsIRetrieveAuditStrategy30;
@@ -54,7 +58,7 @@ public class Rad75AuditStrategyTest extends XdsAuditorTestBase {
                 EventOutcomeIndicator.Success,
                 serverSide ? EventIdCode.DICOMInstancesTransferred: EventIdCode.DICOMInstancesAccessed,
                 serverSide ? EventActionCode.Read : EventActionCode.Create,
-                serverSide,
+                !serverSide,
                 true);
 
         assertEquals(3, auditMessage.findParticipantObjectIdentifications(


### PR DESCRIPTION
Proposition of fix for #326.
The _AlternativeUserID_ attribute filled with the process ID is wrongly set in the destination actor instead of the source actor, as per current specifications.

This only modifies _Iti43ServerAuditStrategy_ instead of _IHEAuditMessageBuilder_, the latter being used in other audit strategies.