### PR TITLE
Remove root attribute of InteractionId in PIXv3Query transformers

### DIFF
--- a/commons/ihe/hl7v3/src/main/java/org/openehealth/ipf/commons/ihe/hl7v3/core/transform/requests/PixV3QueryRequestTransformer.java
+++ b/commons/ihe/hl7v3/src/main/java/org/openehealth/ipf/commons/ihe/hl7v3/core/transform/requests/PixV3QueryRequestTransformer.java
@@ -56,7 +56,7 @@ public class PixV3QueryRequestTransformer {
         // Prepare query with fixed values
         final PRPAIN201309UV02Type query = new PRPAIN201309UV02Type();
         query.setITSVersion("XML_1.0");
-        query.setInteractionId(new II("2.16.840.1.113883.1.18", "PRPA_IN201309UV02"));
+        query.setInteractionId(new II("2.16.840.1.113883.1.6", "PRPA_IN201309UV02"));
         query.setProcessingCode(new CS("P", null, null));
         query.setProcessingModeCode(new CS("T", null, null));
         query.setAcceptAckCode(new CS("AL", null, null));

--- a/commons/ihe/hl7v3/src/main/java/org/openehealth/ipf/commons/ihe/hl7v3/core/transform/responses/PixV3QueryResponseTransformer.java
+++ b/commons/ihe/hl7v3/src/main/java/org/openehealth/ipf/commons/ihe/hl7v3/core/transform/responses/PixV3QueryResponseTransformer.java
@@ -58,7 +58,7 @@ public class PixV3QueryResponseTransformer {
         // Prepare response with fixed values
         final PRPAIN201310UV02Type response = new PRPAIN201310UV02Type();
         response.setITSVersion("XML_1.0");
-        response.setInteractionId(new II("2.16.840.1.113883.1.18", "PRPA_IN201310UV02"));
+        response.setInteractionId(new II("2.16.840.1.113883.1.6", "PRPA_IN201310UV02"));
         response.setProcessingCode(new CS("P", null, null));
         response.setProcessingModeCode(new CS("T", null, null));
         response.setAcceptAckCode(new CS("NE", null, null));


### PR DESCRIPTION
This removes the @root attribute on the interactionId element of PIXv3Query requests and responses.
[The specification](https://ihe.github.io/publications/ITI/TF/Volume2/ITI-45.html#3.45.4.1.2.3) doesn't specify a value for the @root attribute and official examples contain another value (`2.16.840.1.113883.1.6`). The XML Schema doesn't provide any info on that.