### PR TITLE
Implementation of PHARM-5

### DIFF
--- a/commons/ihe/fhir/core/src/main/java/org/openehealth/ipf/commons/ihe/fhir/audit/codes/FhirEventTypeCode.java
+++ b/commons/ihe/fhir/core/src/main/java/org/openehealth/ipf/commons/ihe/fhir/audit/codes/FhirEventTypeCode.java
@@ -33,7 +33,8 @@ public enum FhirEventTypeCode implements EventType, EnumeratedCodedValue<EventTy
     MobilePatientDemographicsQuery("ITI-78", "Mobile Patient Demographics Query"),
     RetrieveATNAAuditEvent("ITI-81", "Retrieve ATNA AuditEvent"),
     MobilePatientIdentifierCrossReferenceQuery("ITI-83", "Mobile Patient Identifier Cross-reference Query"),
-    MobileQueryExistingData("PCC-44", "Mobile Query Existing Data");
+    MobileQueryExistingData("PCC-44", "Mobile Query Existing Data"),
+    QueryPharmacyDocumentsOverMhd("PHARM-5", "Query Pharmacy Documents over MHD");
 
     @Getter
     private final EventType value;

--- a/commons/ihe/fhir/core/src/main/java/org/openehealth/ipf/commons/ihe/fhir/audit/codes/FhirParticipantObjectIdTypeCode.java
+++ b/commons/ihe/fhir/core/src/main/java/org/openehealth/ipf/commons/ihe/fhir/audit/codes/FhirParticipantObjectIdTypeCode.java
@@ -34,7 +34,8 @@ public enum FhirParticipantObjectIdTypeCode implements ParticipantObjectIdType, 
     MobilePatientDemographicsQuery("ITI-78", "Mobile Patient Demographics Query"),
     RetrieveATNAAuditEvent("ITI-81", "Retrieve ATNA AuditEvent"),
     MobilePatientIdentifierCrossReferenceQuery("ITI-83", "Mobile Patient Identifier Cross-reference Query"),
-    MobileQueryExistingData("PCC-44", "Mobile Query Existing Data");
+    MobileQueryExistingData("PCC-44", "Mobile Query Existing Data"),
+    QueryPharmacyDocumentsOverMhd("PHARM-5", "Query Pharmacy Documents over MHD");
 
     @Getter
     private final ParticipantObjectIdType value;

--- a/commons/ihe/fhir/r4/mhd/src/main/java/org/openehealth/ipf/commons/ihe/fhir/mhd/CMPD.java
+++ b/commons/ihe/fhir/r4/mhd/src/main/java/org/openehealth/ipf/commons/ihe/fhir/mhd/CMPD.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openehealth.ipf.commons.ihe.fhir.mhd;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.openehealth.ipf.commons.ihe.core.IntegrationProfile;
+import org.openehealth.ipf.commons.ihe.core.InteractionId;
+import org.openehealth.ipf.commons.ihe.fhir.FhirInteractionId;
+import org.openehealth.ipf.commons.ihe.fhir.FhirTransactionConfiguration;
+import org.openehealth.ipf.commons.ihe.fhir.audit.FhirQueryAuditDataset;
+import org.openehealth.ipf.commons.ihe.fhir.pharm5.Pharm5TransactionConfiguration;
+
+import java.util.List;
+
+/**
+ * Integration profile for MHD-based CMPD transactions.
+ *
+ * @author Quentin Ligier
+ * @since 4.3
+ **/
+public class CMPD implements IntegrationProfile {
+
+    private static final Pharm5TransactionConfiguration PHARM_5_CONFIG = new Pharm5TransactionConfiguration();
+
+    @Override
+    public List<InteractionId> getInteractionIds() {
+        return List.of(QueryPharmacyDocumentsInteractions.values());
+    }
+
+    @AllArgsConstructor
+    public enum QueryPharmacyDocumentsInteractions implements FhirInteractionId<FhirQueryAuditDataset> {
+        PHARM_5(PHARM_5_CONFIG);
+
+        @Getter
+        private final FhirTransactionConfiguration<FhirQueryAuditDataset> fhirTransactionConfiguration;
+    }
+}

--- a/commons/ihe/fhir/r4/mhd/src/main/java/org/openehealth/ipf/commons/ihe/fhir/pharm5/Pharm5AuditStrategy.java
+++ b/commons/ihe/fhir/r4/mhd/src/main/java/org/openehealth/ipf/commons/ihe/fhir/pharm5/Pharm5AuditStrategy.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openehealth.ipf.commons.ihe.fhir.pharm5;
+
+import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.StringType;
+import org.openehealth.ipf.commons.audit.AuditContext;
+import org.openehealth.ipf.commons.audit.codes.ParticipantObjectTypeCode;
+import org.openehealth.ipf.commons.audit.codes.ParticipantObjectTypeCodeRole;
+import org.openehealth.ipf.commons.audit.model.AuditMessage;
+import org.openehealth.ipf.commons.audit.model.TypeValuePairType;
+import org.openehealth.ipf.commons.ihe.core.atna.event.QueryInformationBuilder;
+import org.openehealth.ipf.commons.ihe.fhir.Constants;
+import org.openehealth.ipf.commons.ihe.fhir.audit.FhirAuditStrategy;
+import org.openehealth.ipf.commons.ihe.fhir.audit.FhirQueryAuditDataset;
+import org.openehealth.ipf.commons.ihe.fhir.audit.codes.FhirEventTypeCode;
+import org.openehealth.ipf.commons.ihe.fhir.audit.codes.FhirParticipantObjectIdTypeCode;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+import static org.openehealth.ipf.commons.ihe.fhir.Constants.HTTP_QUERY;
+import static org.openehealth.ipf.commons.ihe.fhir.Constants.HTTP_URL;
+
+/**
+ * Generic Audit Strategy for CMPD PHARM-5 query transactions.
+ *
+ * @author Quentin Ligier
+ * @since 4.3
+ **/
+public class Pharm5AuditStrategy extends FhirAuditStrategy<FhirQueryAuditDataset> {
+
+    public Pharm5AuditStrategy(final boolean serverSide) {
+        super(serverSide);
+    }
+
+    public AuditMessage[] makeAuditMessage(final AuditContext auditContext,
+                                           final FhirQueryAuditDataset auditDataset) {
+        var operation = "unknown";
+        final var endpointUrl = auditDataset.getDestinationUserId();
+        if (endpointUrl != null && endpointUrl.lastIndexOf("$") >= 0) {
+            operation = endpointUrl.substring(endpointUrl.lastIndexOf("$"));
+        }
+        return new QueryInformationBuilder<>(auditContext, auditDataset, FhirEventTypeCode.QueryPharmacyDocumentsOverMhd)
+                .addPatients(auditDataset.getPatientIds())
+                .setQueryParameters(
+                        operation,
+                        FhirParticipantObjectIdTypeCode.QueryPharmacyDocumentsOverMhd,
+                        auditDataset.getQueryString(),
+                        ParticipantObjectTypeCode.System,
+                        ParticipantObjectTypeCodeRole.Query,
+                        List.of(new TypeValuePairType("QueryEncoding", "UTF-8")))
+                .getMessages();
+    }
+
+    /**
+     * Further enrich the audit dataset: add query string and patient IDs in the search parameter (if available).
+     *
+     * @param auditDataset audit dataset
+     * @param request      request object
+     * @param parameters   request parameters
+     * @return enriched audit dataset
+     */
+    @Override
+    public FhirQueryAuditDataset enrichAuditDatasetFromRequest(final FhirQueryAuditDataset auditDataset,
+                                                               final Object request,
+                                                               final Map<String, Object> parameters) {
+        final var dataset = super.enrichAuditDatasetFromRequest(auditDataset, request, parameters);
+
+        final BiConsumer<String, String> addPatientId = (value, system) -> {
+            system = (system.startsWith("urn:oid:")) ?
+                    system.substring(8) :
+                    system;
+            dataset.getPatientIds().add(String.format("%s^^^&%s&ISO", value, system));
+        };
+
+        final var searchParameters = (Pharm5SearchParameters) parameters.get(Constants.FHIR_REQUEST_PARAMETERS);
+        if (searchParameters != null) {
+            final var tokenParams = searchParameters.getPatientIdParam();
+            if (tokenParams != null) {
+                tokenParams.forEach(t -> addPatientId.accept(t.getValue(), t.getSystem()));
+            }
+        } else if (request instanceof Parameters) {
+            final var bodyParameters = (Parameters) request;
+            final var patientIdentifier = bodyParameters.getParameter(Pharm5ResourceProvider.SP_PATIENT_IDENTIFIER);
+            if (patientIdentifier instanceof StringType) {
+                final var parts = ((StringType) patientIdentifier).getValue().split("\\|");
+                addPatientId.accept(parts[1], parts[0]);
+            }
+        }
+
+        if (parameters.containsKey(HTTP_QUERY)) {
+            dataset.setQueryString(URLDecoder.decode((String) parameters.get(HTTP_QUERY), StandardCharsets.UTF_8));
+        }
+        if (parameters.containsKey(HTTP_URL)) {
+            dataset.setServiceEndpointUrl(URLDecoder.decode((String) parameters.get(HTTP_URL), StandardCharsets.UTF_8));
+        }
+
+        return dataset;
+    }
+
+    @Override
+    public FhirQueryAuditDataset createAuditDataset() {
+        return new FhirQueryAuditDataset(isServerSide());
+    }
+}

--- a/commons/ihe/fhir/r4/mhd/src/main/java/org/openehealth/ipf/commons/ihe/fhir/pharm5/Pharm5ClientRequestFactory.java
+++ b/commons/ihe/fhir/r4/mhd/src/main/java/org/openehealth/ipf/commons/ihe/fhir/pharm5/Pharm5ClientRequestFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openehealth.ipf.commons.ihe.fhir.pharm5;
+
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.gclient.IClientExecutable;
+import ca.uhn.fhir.rest.gclient.IOperationUntypedWithInput;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.DocumentReference;
+import org.hl7.fhir.r4.model.Parameters;
+import org.openehealth.ipf.commons.ihe.fhir.ClientRequestFactory;
+import org.openehealth.ipf.commons.ihe.fhir.Constants;
+
+import java.util.Map;
+
+/**
+ * Request Factory for PHARM-5 requests returning a bundle of document references.
+ *
+ * @author Quentin Ligier
+ * @since 4.3
+ **/
+public class Pharm5ClientRequestFactory implements ClientRequestFactory<IOperationUntypedWithInput<Bundle>> {
+
+    @Override
+    public IClientExecutable<IOperationUntypedWithInput<Bundle>, ?> getClientExecutable(final IGenericClient client,
+                                                                                            final Object requestData,
+                                                                                            final Map<String, Object> parameters) {
+
+        final Parameters urlParameters;
+        final String operation;
+
+        if (parameters == null) {
+            throw new IllegalArgumentException("In CMPD PHARM-5, either 'FhirRequestParameters' or 'OPERATION_HEADER' shall be set");
+        }
+
+        if (parameters.containsKey(Constants.FHIR_REQUEST_PARAMETERS)) {
+            final Pharm5SearchParameters searchParameters = (Pharm5SearchParameters) parameters.get(Constants.FHIR_REQUEST_PARAMETERS);
+            urlParameters = searchParameters.toParameters();
+            operation = searchParameters.getOperation().getOperation();
+        } else if (requestData instanceof Parameters) {
+            urlParameters = (Parameters) requestData;
+            if (!parameters.containsKey(Constants.FHIR_OPERATION_HEADER)) {
+                throw new IllegalArgumentException("In CMPD PHARM-5, if using Parameters, the operation name shall be" +
+                        " set in 'FHIR_OPERATION_HEADER'");
+            }
+            operation = ((Pharm5Operations) parameters.get(Constants.FHIR_OPERATION_HEADER)).getOperation();
+        } else {
+            throw new IllegalArgumentException("Missing search parameters for CMPD PHARM-5");
+        }
+
+        return client.operation()
+                .onType(DocumentReference.class)
+                .named(operation)
+                .withParameters(urlParameters)
+                .returnResourceType(Bundle.class)
+                .useHttpGet();
+    }
+}

--- a/commons/ihe/fhir/r4/mhd/src/main/java/org/openehealth/ipf/commons/ihe/fhir/pharm5/Pharm5Operations.java
+++ b/commons/ihe/fhir/r4/mhd/src/main/java/org/openehealth/ipf/commons/ihe/fhir/pharm5/Pharm5Operations.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openehealth.ipf.commons.ihe.fhir.pharm5;
+
+import java.util.Objects;
+
+/**
+ * The different operations of CMPD PHARM-5 transaction.
+ *
+ * @author Quentin Ligier
+ * @since 4.3
+ **/
+public enum Pharm5Operations {
+
+    FIND_MEDICATION_TREATMENT_PLANS("$find-medication-treatment-plans"),
+    FIND_PRESCRIPTIONS("$find-prescriptions"),
+    FIND_DISPENSES("$find-dispenses"),
+    FIND_MEDICATION_ADMINISTRATIONS("$find-medication-administrations"),
+    FIND_PRESCRIPTIONS_FOR_VALIDATION("$find-prescriptions-for-validation"),
+    FIND_PRESCRIPTIONS_FOR_DISPENSE("$find-prescriptions-for-dispense"),
+    FIND_MEDICATION_LIST("$find-medication-list");
+
+    private final String operation;
+
+    Pharm5Operations(final String operation) {
+        this.operation = Objects.requireNonNull(operation);
+    }
+
+    public String getOperation() {
+        return this.operation;
+    }
+}

--- a/commons/ihe/fhir/r4/mhd/src/main/java/org/openehealth/ipf/commons/ihe/fhir/pharm5/Pharm5ResourceProvider.java
+++ b/commons/ihe/fhir/r4/mhd/src/main/java/org/openehealth/ipf/commons/ihe/fhir/pharm5/Pharm5ResourceProvider.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openehealth.ipf.commons.ihe.fhir.pharm5;
+
+import ca.uhn.fhir.model.api.Include;
+import ca.uhn.fhir.model.valueset.BundleTypeEnum;
+import ca.uhn.fhir.rest.annotation.IncludeParam;
+import ca.uhn.fhir.rest.annotation.Operation;
+import ca.uhn.fhir.rest.annotation.OperationParam;
+import ca.uhn.fhir.rest.annotation.Sort;
+import ca.uhn.fhir.rest.api.SortSpec;
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.param.DateRangeParam;
+import ca.uhn.fhir.rest.param.StringParam;
+import ca.uhn.fhir.rest.param.TokenOrListParam;
+import ca.uhn.fhir.rest.param.TokenParam;
+import org.hl7.fhir.r4.model.*;
+import org.openehealth.ipf.commons.ihe.fhir.AbstractPlainProvider;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Set;
+
+/**
+ * Resource Provider for CMPD PHARM-5.
+ *
+ * @author Quentin Ligier
+ * @since 4.3
+ **/
+public class Pharm5ResourceProvider extends AbstractPlainProvider {
+    public static final String SP_PATIENT_IDENTIFIER = DocumentReference.SP_PATIENT + "." + Patient.SP_IDENTIFIER;
+    public static final String SP_AUTHOR_FAMILY = DocumentReference.SP_AUTHOR + "." + Practitioner.SP_FAMILY;
+    public static final String SP_AUTHOR_GIVEN = DocumentReference.SP_AUTHOR + "." + Practitioner.SP_GIVEN;
+
+    @Operation(name = "$find-medication-treatment-plans", type = DocumentReference.class, idempotent = true,
+            bundleType = BundleTypeEnum.SEARCHSET)
+    public IBundleProvider findMedicationTreatmentPlans(
+            @OperationParam(name = SP_PATIENT_IDENTIFIER, min = 1, max = 1) TokenParam patient,
+            @OperationParam(name = DocumentReference.SP_STATUS, min = 1, max = 2) TokenOrListParam status,
+            @OperationParam(name = DocumentReference.SP_IDENTIFIER) TokenParam identifier,
+            @OperationParam(name = DocumentReference.SP_SETTING) TokenOrListParam setting,
+            @OperationParam(name = DocumentReference.SP_DATE) DateRangeParam date,
+            @OperationParam(name = DocumentReference.SP_PERIOD) DateRangeParam period,
+            @OperationParam(name = DocumentReference.SP_FORMAT) TokenOrListParam format,
+            @OperationParam(name = DocumentReference.SP_FACILITY) TokenOrListParam facility,
+            @OperationParam(name = DocumentReference.SP_EVENT) TokenOrListParam event,
+            @OperationParam(name = DocumentReference.SP_SECURITY_LABEL) TokenOrListParam securityLabel,
+            @OperationParam(name = SP_AUTHOR_FAMILY) StringParam authorFamily,
+            @OperationParam(name = SP_AUTHOR_GIVEN) StringParam authorGiven,
+            @Sort SortSpec sortSpec,
+            @IncludeParam Set<Include> includeSpec,
+            RequestDetails requestDetails,
+            HttpServletRequest httpServletRequest,
+            HttpServletResponse httpServletResponse) {
+        return this.stableSearch(patient, identifier, setting, date, period, format, facility, event, securityLabel,
+                authorFamily, authorGiven, status, sortSpec, includeSpec, requestDetails, httpServletRequest,
+                httpServletResponse, Pharm5Operations.FIND_MEDICATION_TREATMENT_PLANS);
+    }
+
+    @Operation(name = "$find-prescriptions", type = DocumentReference.class, idempotent = true,
+            bundleType = BundleTypeEnum.SEARCHSET)
+    public IBundleProvider findPrescriptions(
+            @OperationParam(name = SP_PATIENT_IDENTIFIER, min = 1, max = 1) TokenParam patient,
+            @OperationParam(name = DocumentReference.SP_STATUS, min = 1, max = 2) TokenOrListParam status,
+            @OperationParam(name = DocumentReference.SP_IDENTIFIER) TokenParam identifier,
+            @OperationParam(name = DocumentReference.SP_SETTING) TokenOrListParam setting,
+            @OperationParam(name = DocumentReference.SP_DATE) DateRangeParam date,
+            @OperationParam(name = DocumentReference.SP_PERIOD) DateRangeParam period,
+            @OperationParam(name = DocumentReference.SP_FORMAT) TokenOrListParam format,
+            @OperationParam(name = DocumentReference.SP_FACILITY) TokenOrListParam facility,
+            @OperationParam(name = DocumentReference.SP_EVENT) TokenOrListParam event,
+            @OperationParam(name = DocumentReference.SP_SECURITY_LABEL) TokenOrListParam securityLabel,
+            @OperationParam(name = SP_AUTHOR_FAMILY) StringParam authorFamily,
+            @OperationParam(name = SP_AUTHOR_GIVEN) StringParam authorGiven,
+            @Sort SortSpec sortSpec,
+            @IncludeParam Set<Include> includeSpec,
+            RequestDetails requestDetails,
+            HttpServletRequest httpServletRequest,
+            HttpServletResponse httpServletResponse) {
+        return this.stableSearch(patient, identifier, setting, date, period, format, facility, event, securityLabel,
+                authorFamily, authorGiven, status, sortSpec, includeSpec, requestDetails, httpServletRequest, httpServletResponse,
+                Pharm5Operations.FIND_PRESCRIPTIONS);
+    }
+
+    @Operation(name = "$find-dispenses", type = DocumentReference.class, idempotent = true,
+            bundleType = BundleTypeEnum.SEARCHSET)
+    public IBundleProvider findDispenses(
+            @OperationParam(name = SP_PATIENT_IDENTIFIER, min = 1, max = 1) TokenParam patient,
+            @OperationParam(name = DocumentReference.SP_STATUS, min = 1, max = 2) TokenOrListParam status,
+            @OperationParam(name = DocumentReference.SP_IDENTIFIER) TokenParam identifier,
+            @OperationParam(name = DocumentReference.SP_SETTING) TokenOrListParam setting,
+            @OperationParam(name = DocumentReference.SP_DATE) DateRangeParam date,
+            @OperationParam(name = DocumentReference.SP_PERIOD) DateRangeParam period,
+            @OperationParam(name = DocumentReference.SP_FORMAT) TokenOrListParam format,
+            @OperationParam(name = DocumentReference.SP_FACILITY) TokenOrListParam facility,
+            @OperationParam(name = DocumentReference.SP_EVENT) TokenOrListParam event,
+            @OperationParam(name = DocumentReference.SP_SECURITY_LABEL) TokenOrListParam securityLabel,
+            @OperationParam(name = SP_AUTHOR_FAMILY) StringParam authorFamily,
+            @OperationParam(name = SP_AUTHOR_GIVEN) StringParam authorGiven,
+            @Sort SortSpec sortSpec,
+            @IncludeParam Set<Include> includeSpec,
+            RequestDetails requestDetails,
+            HttpServletRequest httpServletRequest,
+            HttpServletResponse httpServletResponse) {
+        return this.stableSearch(patient, identifier, setting, date, period, format, facility, event, securityLabel,
+                authorFamily, authorGiven, status, sortSpec, includeSpec, requestDetails, httpServletRequest, httpServletResponse,
+                Pharm5Operations.FIND_DISPENSES);
+    }
+
+    @Operation(name = "$find-medication-administrations", type = DocumentReference.class, idempotent = true,
+            bundleType = BundleTypeEnum.SEARCHSET)
+    public IBundleProvider findMedicationAdministrations(
+            @OperationParam(name = SP_PATIENT_IDENTIFIER, min = 1, max = 1) TokenParam patient,
+            @OperationParam(name = DocumentReference.SP_STATUS, min = 1, max = 2) TokenOrListParam status,
+            @OperationParam(name = DocumentReference.SP_IDENTIFIER) TokenParam identifier,
+            @OperationParam(name = DocumentReference.SP_SETTING) TokenOrListParam setting,
+            @OperationParam(name = DocumentReference.SP_DATE) DateRangeParam date,
+            @OperationParam(name = DocumentReference.SP_PERIOD) DateRangeParam period,
+            @OperationParam(name = DocumentReference.SP_FORMAT) TokenOrListParam format,
+            @OperationParam(name = DocumentReference.SP_FACILITY) TokenOrListParam facility,
+            @OperationParam(name = DocumentReference.SP_EVENT) TokenOrListParam event,
+            @OperationParam(name = DocumentReference.SP_SECURITY_LABEL) TokenOrListParam securityLabel,
+            @OperationParam(name = SP_AUTHOR_FAMILY) StringParam authorFamily,
+            @OperationParam(name = SP_AUTHOR_GIVEN) StringParam authorGiven,
+            @Sort SortSpec sortSpec,
+            @IncludeParam Set<Include> includeSpec,
+            RequestDetails requestDetails,
+            HttpServletRequest httpServletRequest,
+            HttpServletResponse httpServletResponse) {
+        return this.stableSearch(patient, identifier, setting, date, period, format, facility, event, securityLabel,
+                authorFamily, authorGiven, status, sortSpec, includeSpec, requestDetails, httpServletRequest, httpServletResponse,
+                Pharm5Operations.FIND_MEDICATION_ADMINISTRATIONS);
+    }
+
+    @Operation(name = "$find-prescriptions-for-validation", type = DocumentReference.class, idempotent = true,
+            bundleType = BundleTypeEnum.SEARCHSET)
+    public IBundleProvider findPrescriptionsForValidation(
+            @OperationParam(name = SP_PATIENT_IDENTIFIER, min = 1, max = 1) TokenParam patient,
+            @OperationParam(name = DocumentReference.SP_STATUS, min = 1, max = 2) TokenOrListParam status,
+            @OperationParam(name = DocumentReference.SP_IDENTIFIER) TokenParam identifier,
+            @OperationParam(name = DocumentReference.SP_SETTING) TokenOrListParam setting,
+            @OperationParam(name = DocumentReference.SP_DATE) DateRangeParam date,
+            @OperationParam(name = DocumentReference.SP_PERIOD) DateRangeParam period,
+            @OperationParam(name = DocumentReference.SP_FORMAT) TokenOrListParam format,
+            @OperationParam(name = DocumentReference.SP_FACILITY) TokenOrListParam facility,
+            @OperationParam(name = DocumentReference.SP_EVENT) TokenOrListParam event,
+            @OperationParam(name = DocumentReference.SP_SECURITY_LABEL) TokenOrListParam securityLabel,
+            @OperationParam(name = SP_AUTHOR_FAMILY) StringParam authorFamily,
+            @OperationParam(name = SP_AUTHOR_GIVEN) StringParam authorGiven,
+            @Sort SortSpec sortSpec,
+            @IncludeParam Set<Include> includeSpec,
+            RequestDetails requestDetails,
+            HttpServletRequest httpServletRequest,
+            HttpServletResponse httpServletResponse) {
+        return this.stableSearch(patient, identifier, setting, date, period, format, facility, event, securityLabel,
+                authorFamily, authorGiven, status, sortSpec, includeSpec, requestDetails, httpServletRequest, httpServletResponse,
+                Pharm5Operations.FIND_PRESCRIPTIONS_FOR_VALIDATION);
+    }
+
+    @Operation(name = "$find-prescriptions-for-dispense", type = DocumentReference.class, idempotent = true,
+            bundleType = BundleTypeEnum.SEARCHSET)
+    public IBundleProvider findPrescriptionsForDispense(
+            @OperationParam(name = SP_PATIENT_IDENTIFIER, min = 1, max = 1) TokenParam patient,
+            @OperationParam(name = DocumentReference.SP_STATUS, min = 1, max = 2) TokenOrListParam status,
+            @OperationParam(name = DocumentReference.SP_IDENTIFIER) TokenParam identifier,
+            @OperationParam(name = DocumentReference.SP_SETTING) TokenOrListParam setting,
+            @OperationParam(name = DocumentReference.SP_DATE) DateRangeParam date,
+            @OperationParam(name = DocumentReference.SP_PERIOD) DateRangeParam period,
+            @OperationParam(name = DocumentReference.SP_FORMAT) TokenOrListParam format,
+            @OperationParam(name = DocumentReference.SP_FACILITY) TokenOrListParam facility,
+            @OperationParam(name = DocumentReference.SP_EVENT) TokenOrListParam event,
+            @OperationParam(name = DocumentReference.SP_SECURITY_LABEL) TokenOrListParam securityLabel,
+            @OperationParam(name = SP_AUTHOR_FAMILY) StringParam authorFamily,
+            @OperationParam(name = SP_AUTHOR_GIVEN) StringParam authorGiven,
+            @Sort SortSpec sortSpec,
+            @IncludeParam Set<Include> includeSpec,
+            RequestDetails requestDetails,
+            HttpServletRequest httpServletRequest,
+            HttpServletResponse httpServletResponse) {
+        return this.stableSearch(patient, identifier, setting, date, period, format, facility, event, securityLabel,
+                authorFamily, authorGiven, status, sortSpec, includeSpec, requestDetails, httpServletRequest, httpServletResponse,
+                Pharm5Operations.FIND_PRESCRIPTIONS_FOR_DISPENSE);
+    }
+
+    // The method is not idempotent, but we need it to support GET requests
+    @Operation(name = "$find-medication-list", type = DocumentReference.class, idempotent = true,
+            bundleType = BundleTypeEnum.SEARCHSET)
+    public IBundleProvider findMedicationList(
+            @OperationParam(name = SP_PATIENT_IDENTIFIER, min = 1, max = 1) TokenParam patient,
+            @OperationParam(name = DocumentReference.SP_STATUS, min = 1, max = 2) TokenOrListParam status,
+            @OperationParam(name = DocumentReference.SP_PERIOD) DateRangeParam period,
+            @OperationParam(name = DocumentReference.SP_FORMAT) TokenOrListParam format,
+            @Sort SortSpec sortSpec,
+            @IncludeParam Set<Include> includeSpec,
+            RequestDetails requestDetails,
+            HttpServletRequest httpServletRequest,
+            HttpServletResponse httpServletResponse) {
+        final var searchParameters = Pharm5SearchParameters.builder()
+                .status(status)
+                .period(period)
+                .format(format)
+                .patientIdentifier(patient)
+                .sortSpec(sortSpec)
+                .includeSpec(includeSpec)
+                .fhirContext(getFhirContext())
+                .operation(Pharm5Operations.FIND_MEDICATION_LIST)
+                .build();
+
+        // Run down the route
+        return requestBundleProvider(null, searchParameters, ResourceType.DocumentReference.name(),
+                httpServletRequest, httpServletResponse, requestDetails);
+    }
+
+    IBundleProvider stableSearch(final TokenParam patient,
+                                 final TokenParam identifier,
+                                 final TokenOrListParam setting,
+                                 final DateRangeParam date,
+                                 final DateRangeParam period,
+                                 final TokenOrListParam format,
+                                 final TokenOrListParam facility,
+                                 final TokenOrListParam event,
+                                 final TokenOrListParam securityLabel,
+                                 final StringParam authorFamily,
+                                 final StringParam authorGiven,
+                                 final TokenOrListParam status,
+                                 final SortSpec sortSpec,
+                                 final Set<Include> includeSpec,
+                                 final RequestDetails requestDetails,
+                                 final HttpServletRequest httpServletRequest,
+                                 final HttpServletResponse httpServletResponse,
+                                 final Pharm5Operations operation) {
+
+        final var searchParameters = Pharm5SearchParameters.builder()
+                .patientIdentifier(patient)
+                .status(status)
+                .identifier(identifier)
+                .setting(setting)
+                .date(date)
+                .period(period)
+                .facility(facility)
+                .event(event)
+                .securityLabel(securityLabel)
+                .format(format)
+                .authorFamilyName(authorFamily)
+                .authorGivenName(authorGiven)
+                .sortSpec(sortSpec)
+                .includeSpec(includeSpec)
+                .fhirContext(getFhirContext())
+                .operation(operation)
+                .build();
+
+        // Run down the route
+        return requestBundleProvider(null, searchParameters, ResourceType.DocumentReference.name(),
+                httpServletRequest, httpServletResponse, requestDetails);
+    }
+}

--- a/commons/ihe/fhir/r4/mhd/src/main/java/org/openehealth/ipf/commons/ihe/fhir/pharm5/Pharm5SearchParameters.java
+++ b/commons/ihe/fhir/r4/mhd/src/main/java/org/openehealth/ipf/commons/ihe/fhir/pharm5/Pharm5SearchParameters.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openehealth.ipf.commons.ihe.fhir.pharm5;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.model.api.Include;
+import ca.uhn.fhir.rest.api.SortOrderEnum;
+import ca.uhn.fhir.rest.api.SortSpec;
+import ca.uhn.fhir.rest.param.*;
+import ca.uhn.fhir.util.UrlUtil;
+import lombok.*;
+import org.hl7.fhir.r4.model.*;
+import org.openehealth.ipf.commons.ihe.fhir.FhirSearchAndSortParameters;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static java.util.Comparator.comparing;
+import static java.util.Comparator.nullsLast;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+/**
+ * Search parameters for CMPD PHARM-5 transaction.
+ *
+ * @author Christian Ohr
+ * @author Quentin Ligier
+ * @since 4.3
+ */
+@Builder
+@ToString
+@AllArgsConstructor
+public class Pharm5SearchParameters extends FhirSearchAndSortParameters<DocumentReference> {
+
+    @Getter @Setter private TokenParam patientIdentifier;
+    @Getter @Setter private DateRangeParam date;
+    @Getter @Setter private StringParam authorFamilyName;
+    @Getter @Setter private StringParam authorGivenName;
+    @Getter @Setter private TokenParam identifier;
+    @Getter @Setter private TokenOrListParam status;
+    @Getter @Setter private TokenOrListParam setting;
+    @Getter @Setter private DateRangeParam period;
+    @Getter @Setter private TokenOrListParam facility;
+    @Getter @Setter private TokenOrListParam event;
+    @Getter @Setter private TokenOrListParam securityLabel;
+    @Getter @Setter private TokenOrListParam format;
+    @Getter @Setter private Pharm5Operations operation;
+
+    @Getter @Setter private SortSpec sortSpec;
+    @Getter @Setter private Set<Include> includeSpec;
+
+    @Getter private final FhirContext fhirContext;
+
+
+    @Override
+    public List<TokenParam> getPatientIdParam() {
+        return (patientIdentifier != null) ? List.of(patientIdentifier) : Collections.emptyList();
+    }
+
+    public Pharm5SearchParameters setAuthor(final ReferenceAndListParam author) {
+        if (author != null) {
+            author.getValuesAsQueryTokens().forEach(param -> {
+                var ref = param.getValuesAsQueryTokens().get(0);
+                var authorChain = ref.getChain();
+                if (Practitioner.SP_FAMILY.equals(authorChain)) {
+                    setAuthorFamilyName(ref.toStringParam(getFhirContext()));
+                } else if (Practitioner.SP_GIVEN.equals(authorChain)) {
+                    setAuthorGivenName(ref.toStringParam(getFhirContext()));
+                }
+            });
+        }
+        return this;
+    }
+
+    @Override
+    public Optional<Comparator<DocumentReference>> comparatorFor(final String paramName) {
+        if (DocumentReference.SP_DATE.equals(paramName)) {
+            return Optional.of(CP_DATE);
+        } else if (DocumentReference.SP_AUTHOR.equals(paramName)) {
+            return Optional.of(CP_AUTHOR);
+        }
+        return Optional.empty();
+    }
+
+    public String getQueryString(FhirContext context) {
+        return this.patientIdentifier.getValueAsQueryToken(context);
+    }
+
+
+    /**
+     * Maps the {@link Pharm5SearchParameters} to an equivalent {@link Parameters}, for the given FHIR context.
+     */
+    public Parameters toParameters() {
+        final var parameters = new Parameters();
+
+        if (this.getPatientIdentifier() != null) {
+            parameters.addParameter(Pharm5ResourceProvider.SP_PATIENT_IDENTIFIER,
+                    new StringType(this.getPatientIdentifier().getValueAsQueryToken(fhirContext)));
+        }
+        if (this.getDate() != null) {
+            this.getDate().getValuesAsQueryTokens().forEach(dateParam -> parameters.addParameter(DocumentReference.SP_DATE, new StringType(dateParam.getValueAsQueryToken(fhirContext))));
+        }
+        if (this.getAuthorFamilyName() != null) {
+            parameters.addParameter(Pharm5ResourceProvider.SP_AUTHOR_FAMILY,
+                    new StringType(this.getAuthorFamilyName().getValueAsQueryToken(fhirContext)));
+        }
+        if (this.getAuthorGivenName() != null) {
+            parameters.addParameter(Pharm5ResourceProvider.SP_AUTHOR_GIVEN,
+                    new StringType(this.getAuthorGivenName().getValueAsQueryToken(fhirContext)));
+        }
+        if (this.getIdentifier() != null) {
+            parameters.addParameter(DocumentReference.SP_IDENTIFIER,
+                    new StringType(this.getIdentifier().getValueAsQueryToken(fhirContext)));
+        }
+        if (this.getStatus() != null) {
+            parameters.addParameter(DocumentReference.SP_STATUS, new StringType(
+                    this.getStatus().getValuesAsQueryTokens().stream()
+                            .map(tokenParam -> tokenParam.getValueAsQueryToken(fhirContext))
+                            .collect(Collectors.joining(","))
+            ));
+        }
+        if (this.getSetting() != null) {
+            parameters.addParameter(DocumentReference.SP_SETTING, new StringType(
+                    this.getSetting().getValuesAsQueryTokens().stream()
+                            .map(tokenParam -> tokenParam.getValueAsQueryToken(fhirContext))
+                            .collect(Collectors.joining(","))
+            ));
+        }
+        if (this.getPeriod() != null) {
+            this.getPeriod().getValuesAsQueryTokens().forEach(dateParam -> parameters.addParameter(DocumentReference.SP_PERIOD, new StringType(dateParam.getValueAsQueryToken(fhirContext))));
+        }
+        if (this.getFacility() != null) {
+            parameters.addParameter(DocumentReference.SP_FACILITY, new StringType(
+                    this.getFacility().getValuesAsQueryTokens().stream()
+                            .map(tokenParam -> tokenParam.getValueAsQueryToken(fhirContext))
+                            .collect(Collectors.joining(","))
+            ));
+        }
+        if (this.getEvent() != null) {
+            parameters.addParameter(DocumentReference.SP_EVENT, new StringType(
+                    this.getEvent().getValuesAsQueryTokens().stream()
+                            .map(tokenParam -> tokenParam.getValueAsQueryToken(fhirContext))
+                            .collect(Collectors.joining(","))
+            ));
+        }
+        if (this.getSecurityLabel() != null) {
+            parameters.addParameter(DocumentReference.SP_SECURITY_LABEL, new StringType(
+                    this.getSecurityLabel().getValuesAsQueryTokens().stream()
+                            .map(tokenParam -> tokenParam.getValueAsQueryToken(fhirContext))
+                            .collect(Collectors.joining(","))
+            ));
+        }
+        if (this.getFormat() != null) {
+            parameters.addParameter(DocumentReference.SP_FORMAT, new StringType(
+                    this.getFormat().getValuesAsQueryTokens().stream()
+                            .map(tokenParam -> tokenParam.getValueAsQueryToken(fhirContext))
+                            .collect(Collectors.joining(","))
+            ));
+        }
+
+        if (this.getSortSpec() != null) {
+            SortSpec sort = this.getSortSpec();
+            boolean first = true;
+            final var b = new StringBuilder();
+            while (sort != null) {
+                if (!first) {
+                    b.append(',');
+                }
+                if (sort.getOrder() == SortOrderEnum.DESC) {
+                    b.append('-');
+                }
+                b.append(sort.getParamName());
+                sort = sort.getChain();
+                first = false;
+            }
+            parameters.addParameter(ca.uhn.fhir.rest.api.Constants.PARAM_SORT, new StringType(b.toString()));
+        }
+        if (this.getIncludeSpec() != null) {
+            for (final Include nextInclude : this.getIncludeSpec()) {
+                final var b = new StringBuilder();
+                b.append(UrlUtil.escapeUrlParam(nextInclude.getParamType()));
+                b.append(':');
+                b.append(UrlUtil.escapeUrlParam(nextInclude.getParamName()));
+                if (isNotBlank(nextInclude.getParamTargetType())) {
+                    b.append(':');
+                    b.append(nextInclude.getParamTargetType());
+                }
+
+                final var paramName = (nextInclude.isRecurse())
+                        ? ca.uhn.fhir.rest.api.Constants.PARAM_INCLUDE_ITERATE
+                        : ca.uhn.fhir.rest.api.Constants.PARAM_INCLUDE;
+                parameters.addParameter(paramName, new StringType(b.toString()));
+            }
+        }
+
+        return parameters;
+    }
+
+    private static final Comparator<DocumentReference> CP_DATE = nullsLast(comparing(DocumentReference::getDate));
+
+    private static final Comparator<DocumentReference> CP_AUTHOR = nullsLast(comparing(documentReference -> {
+        if (!documentReference.hasAuthor()) return null;
+        var author = documentReference.getAuthorFirstRep();
+        if (author.getResource() instanceof PractitionerRole) {
+            var practitionerRole = (PractitionerRole) author.getResource();
+            if (!practitionerRole.hasPractitioner()) return null;
+            author = practitionerRole.getPractitioner();
+        }
+        if (author.getResource() == null) return null;
+        if (author.getResource() instanceof Practitioner) {
+            var practitioner = (Practitioner) author.getResource();
+            if (!practitioner.hasName()) return null;
+            var name = practitioner.getNameFirstRep();
+            return name.getFamilyElement().getValueNotNull() + name.getGivenAsSingleString();
+        }
+        return null;
+    }));
+}

--- a/commons/ihe/fhir/r4/mhd/src/main/java/org/openehealth/ipf/commons/ihe/fhir/pharm5/Pharm5TransactionConfiguration.java
+++ b/commons/ihe/fhir/r4/mhd/src/main/java/org/openehealth/ipf/commons/ihe/fhir/pharm5/Pharm5TransactionConfiguration.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openehealth.ipf.commons.ihe.fhir.pharm5;
+
+import ca.uhn.fhir.context.FhirVersionEnum;
+import org.openehealth.ipf.commons.ihe.fhir.FhirTransactionConfiguration;
+import org.openehealth.ipf.commons.ihe.fhir.FhirTransactionValidator;
+import org.openehealth.ipf.commons.ihe.fhir.audit.FhirQueryAuditDataset;
+
+/**
+ * Static configuration for CMPD PHARM-5 transaction components
+ *
+ * @author Quentin Ligier
+ * @since 4.3
+ **/
+public class Pharm5TransactionConfiguration extends FhirTransactionConfiguration<FhirQueryAuditDataset> {
+
+    public Pharm5TransactionConfiguration() {
+        super("cmpd-pharm5",
+                "PHARM-5",
+                true,
+                new Pharm5AuditStrategy(false),
+                new Pharm5AuditStrategy(true),
+                FhirVersionEnum.R4,
+                new Pharm5ResourceProvider(), // Consumer side. accept registrations
+                new Pharm5ClientRequestFactory(),
+                FhirTransactionValidator.NO_VALIDATION);
+        setSupportsLazyLoading(false);
+    }
+}

--- a/commons/ihe/fhir/r4/mhd/src/test/java/org/openehealth/ipf/commons/ihe/fhir/pharm5/Pharm5SearchParametersTest.java
+++ b/commons/ihe/fhir/r4/mhd/src/test/java/org/openehealth/ipf/commons/ihe/fhir/pharm5/Pharm5SearchParametersTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openehealth.ipf.commons.ihe.fhir.pharm5;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.model.api.Include;
+import ca.uhn.fhir.rest.api.SortOrderEnum;
+import ca.uhn.fhir.rest.api.SortSpec;
+import ca.uhn.fhir.rest.param.*;
+import ca.uhn.fhir.util.UrlUtil;
+import org.hl7.fhir.r4.model.Parameters;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link Pharm5SearchParameters}.
+ *
+ * @author Quentin Ligier
+ **/
+class Pharm5SearchParametersTest {
+
+    @Test
+    void testToParameters() {
+        final var fhirContext = FhirContext.forR4();
+
+        final var searchParameters = new Pharm5SearchParameters(
+                new TokenParam("urn:oid:1.2.3", "1234"),
+                new DateRangeParam(
+                        new DateParam(ParamPrefixEnum.GREATERTHAN, "2022-01-01"),
+                        new DateParam(ParamPrefixEnum.LESSTHAN, "2022-03-31")
+                ),
+                new StringParam("Doe"),
+                new StringParam("John"),
+                new TokenParam("abc"),
+                new TokenOrListParam(null, "current"),
+                new TokenOrListParam("urn:oid:1.2.9", "setting1", "setting2"),
+                new DateRangeParam(
+                        new DateParam(ParamPrefixEnum.GREATERTHAN, "2022-02-02"),
+                        new DateParam(ParamPrefixEnum.LESSTHAN, "2022-02-04")
+                ),
+                new TokenOrListParam(null, "fa"),
+                new TokenOrListParam(null, "e"),
+                new TokenOrListParam(null, "s"),
+                new TokenOrListParam(null, "fo"),
+                Pharm5Operations.FIND_MEDICATION_ADMINISTRATIONS,
+                new SortSpec("date", SortOrderEnum.ASC, new SortSpec("status", SortOrderEnum.DESC)),
+                Set.of(new Include("Provenance:target:DocumentReference", true)),
+                fhirContext
+        );
+
+        assertEquals(
+                "patient.identifier=urn%3Aoid%3A1.2.3%7C1234&date=gt2022-01-01&date=lt2022-03-31&author.family=Doe&author.given=John&identifier=abc&status=current&setting=urn%3Aoid%3A1.2.9%7Csetting1%2Curn%3Aoid%3A1.2.9%7Csetting2&period=gt2022-02-02&period=lt2022-02-04&facility=fa&event=e&security-label=s&format=fo&_sort=date%2C-status&_include%3Aiterate=Provenance%3Atarget%3ADocumentReference",
+                this.toQueryString(searchParameters.toParameters()));
+    }
+
+    private String toQueryString(final Parameters parameters) {
+        final var b = new StringBuilder();
+        boolean first = true;
+        for (final var param : parameters.getParameter()) {
+            if (!first) {
+                b.append('&');
+            }
+            b.append(UrlUtil.escapeUrlParam(param.getName()));
+            b.append('=');
+            b.append(UrlUtil.escapeUrlParam(param.getValue().primitiveValue()));
+            first = false;
+        }
+        return b.toString();
+    }
+}

--- a/platform-camel/ihe/fhir/r4/mhd/src/main/java/org/openehealth/ipf/platform/camel/ihe/fhir/pharm5/Pharm5Component.java
+++ b/platform-camel/ihe/fhir/r4/mhd/src/main/java/org/openehealth/ipf/platform/camel/ihe/fhir/pharm5/Pharm5Component.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openehealth.ipf.platform.camel.ihe.fhir.pharm5;
+
+import org.apache.camel.CamelContext;
+import org.openehealth.ipf.commons.ihe.fhir.audit.FhirQueryAuditDataset;
+import org.openehealth.ipf.platform.camel.ihe.fhir.core.FhirComponent;
+import org.openehealth.ipf.platform.camel.ihe.fhir.core.FhirEndpointConfiguration;
+
+import static org.openehealth.ipf.commons.ihe.fhir.mhd.CMPD.QueryPharmacyDocumentsInteractions.PHARM_5;
+
+/**
+ * Component for MHD-based, CMPD Query Pharmacy Documents over MHD (PHARM-5)
+ *
+ * @author Quentin Ligier
+ * @since 4.3
+ **/
+public class Pharm5Component extends FhirComponent<FhirQueryAuditDataset> {
+
+    public Pharm5Component() {
+        super(PHARM_5);
+    }
+
+    public Pharm5Component(final CamelContext context) {
+        super(context, PHARM_5);
+    }
+
+    @Override
+    protected Pharm5Endpoint doCreateEndpoint(final String uri,
+                                              final FhirEndpointConfiguration<FhirQueryAuditDataset> config) {
+        return new Pharm5Endpoint(uri, this, config);
+    }
+}

--- a/platform-camel/ihe/fhir/r4/mhd/src/main/java/org/openehealth/ipf/platform/camel/ihe/fhir/pharm5/Pharm5Endpoint.java
+++ b/platform-camel/ihe/fhir/r4/mhd/src/main/java/org/openehealth/ipf/platform/camel/ihe/fhir/pharm5/Pharm5Endpoint.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openehealth.ipf.platform.camel.ihe.fhir.pharm5;
+
+import org.openehealth.ipf.commons.ihe.fhir.audit.FhirQueryAuditDataset;
+import org.openehealth.ipf.platform.camel.ihe.fhir.core.FhirEndpoint;
+import org.openehealth.ipf.platform.camel.ihe.fhir.core.FhirEndpointConfiguration;
+
+/**
+ * Component for MHD-based, CMPD Query Pharmacy Documents over MHD (PHARM-5)
+ *
+ * @author Quentin Ligier
+ * @since 4.3
+ **/
+public class Pharm5Endpoint extends FhirEndpoint<FhirQueryAuditDataset, Pharm5Component> {
+
+    public Pharm5Endpoint(final String uri,
+                          final Pharm5Component fhirComponent,
+                          final FhirEndpointConfiguration<FhirQueryAuditDataset> config) {
+        super(uri, fhirComponent, config);
+    }
+
+    @Override
+    protected String createEndpointUri() {
+        return "mhd-pharm5:" + "not-implemented yet";
+    }
+}

--- a/platform-camel/ihe/fhir/r4/mhd/src/main/resources/META-INF/services/org/apache/camel/component/cmpd-pharm5
+++ b/platform-camel/ihe/fhir/r4/mhd/src/main/resources/META-INF/services/org/apache/camel/component/cmpd-pharm5
@@ -1,0 +1,12 @@
+#    Copyright 2022 the original author or authors. Licensed under the Apache
+#    License, Version 2.0 (the "License"); you may not use this file except
+#    in compliance with the License. You may obtain a copy of the License at
+#    http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable
+#    law or agreed to in writing, software distributed under the License is
+#    distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#    KIND, either express or implied. See the License for the specific
+#    language governing permissions and limitations under the License.
+
+# Camel registration for the cmpd-pharm5 component
+
+class=org.openehealth.ipf.platform.camel.ihe.fhir.pharm5.Pharm5Component

--- a/platform-camel/ihe/fhir/r4/mhd/src/test/java/org/openehealth/ipf/platform/camel/ihe/fhir/pharm5/AbstractTestPharm5.java
+++ b/platform-camel/ihe/fhir/r4/mhd/src/test/java/org/openehealth/ipf/platform/camel/ihe/fhir/pharm5/AbstractTestPharm5.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openehealth.ipf.platform.camel.ihe.fhir.pharm5;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
+import ca.uhn.fhir.rest.param.TokenOrListParam;
+import ca.uhn.fhir.rest.param.TokenParam;
+import org.hl7.fhir.r4.model.Bundle;
+import org.openehealth.ipf.commons.ihe.fhir.Constants;
+import org.openehealth.ipf.commons.ihe.fhir.IpfFhirServlet;
+import org.openehealth.ipf.commons.ihe.fhir.pharm5.Pharm5ClientRequestFactory;
+import org.openehealth.ipf.commons.ihe.fhir.pharm5.Pharm5Operations;
+import org.openehealth.ipf.commons.ihe.fhir.pharm5.Pharm5SearchParameters;
+import org.openehealth.ipf.platform.camel.ihe.fhir.test.FhirTestContainer;
+
+import java.util.HashMap;
+
+/**
+ *
+ */
+abstract class AbstractTestPharm5 extends FhirTestContainer {
+
+
+    public static void startServer(String contextDescriptor) {
+        var servlet = new IpfFhirServlet(FhirVersionEnum.R4);
+        startServer(servlet, contextDescriptor, false, DEMO_APP_PORT, "FhirServlet");
+        startClient(String.format("http://localhost:%d/", DEMO_APP_PORT));
+    }
+
+    protected Pharm5SearchParameters findMedicationTreatmentPlanParameters() {
+        return new Pharm5SearchParameters(
+                new TokenParam("urn:oid:1.2.3", "1234"),
+                null,
+                null,
+                null,
+                null,
+                new TokenOrListParam(null, "current"),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                Pharm5Operations.FIND_MEDICATION_TREATMENT_PLANS,
+                null,
+                null,
+                FhirContext.forR4()
+        );
+    }
+
+    protected Pharm5SearchParameters findMedicationListParameters() {
+        return new Pharm5SearchParameters(
+                new TokenParam("urn:oid:1.2.3", "abc"),
+                null,
+                null,
+                null,
+                null,
+                new TokenOrListParam(null, "current"),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                Pharm5Operations.FIND_MEDICATION_LIST,
+                null,
+                null,
+                FhirContext.forR4()
+        );
+    }
+
+    protected Bundle sendManually(Pharm5SearchParameters requestData) {
+        final var inParams = new HashMap<String, Object>(1);
+        inParams.put(Constants.FHIR_REQUEST_PARAMETERS, requestData);
+        return (new Pharm5ClientRequestFactory()).getClientExecutable(client, null, inParams)
+                .encodedXml()
+                .execute();
+    }
+
+    protected Bundle nextPage(Bundle bundle) {
+        return client.loadPage()
+                .next(bundle)
+                .execute();
+    }
+
+    protected Bundle previousPage(Bundle bundle) {
+        return client.loadPage()
+                .previous(bundle)
+                .execute();
+    }
+
+
+}

--- a/platform-camel/ihe/fhir/r4/mhd/src/test/java/org/openehealth/ipf/platform/camel/ihe/fhir/pharm5/Pharm5TestRouteBuilder.java
+++ b/platform-camel/ihe/fhir/r4/mhd/src/test/java/org/openehealth/ipf/platform/camel/ihe/fhir/pharm5/Pharm5TestRouteBuilder.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openehealth.ipf.platform.camel.ihe.fhir.pharm5;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.support.ExpressionAdapter;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.DocumentReference;
+import org.openehealth.ipf.commons.ihe.fhir.Constants;
+import org.openehealth.ipf.commons.ihe.fhir.pharm5.Pharm5SearchParameters;
+import org.openehealth.ipf.platform.camel.ihe.fhir.test.FhirTestContainer;
+
+import java.io.InputStreamReader;
+import java.util.stream.Collectors;
+
+/**
+ *
+ */
+public class Pharm5TestRouteBuilder extends RouteBuilder {
+
+    private final boolean returnError;
+
+    public Pharm5TestRouteBuilder(boolean returnError) {
+        this.returnError = returnError;
+    }
+
+    @Override
+    public void configure() throws Exception {
+
+        from("direct:input")
+                .toF("cmpd-pharm5:localhost:%d?fhirContext=#fhirContext", FhirTestContainer.DEMO_APP_PORT);
+
+        from("cmpd-pharm5:translation?audit=true&fhirContext=#fhirContext")
+                .errorHandler(noErrorHandler())
+                .transform(new Pharm5Responder());
+    }
+
+
+    private class Pharm5Responder extends ExpressionAdapter {
+
+        @Override
+        public Object evaluate(Exchange exchange) {
+            if (!returnError) {
+                var resource = FhirContext.forR4().newXmlParser()
+                        .parseResource(Bundle.class, new InputStreamReader(getClass().getResourceAsStream("/FindDocumentReferencesResponse.xml")));
+                // The endpoint expects a list of resources rather than a bundle
+                final var resources = resource.getEntry().stream()
+                        .map(Bundle.BundleEntryComponent::getResource)
+                        .collect(Collectors.toList());
+
+                final var searchParameters = exchange.getIn().getHeader(Constants.FHIR_REQUEST_PARAMETERS, Pharm5SearchParameters.class);
+                ((DocumentReference) resources.get(0)).setDescription(searchParameters.getOperation().getOperation());
+                return resources;
+            } else {
+                throw new InternalErrorException("Something went wrong");
+            }
+        }
+    }
+
+}

--- a/platform-camel/ihe/fhir/r4/mhd/src/test/java/org/openehealth/ipf/platform/camel/ihe/fhir/pharm5/TestPharm5Error.java
+++ b/platform-camel/ihe/fhir/r4/mhd/src/test/java/org/openehealth/ipf/platform/camel/ihe/fhir/pharm5/TestPharm5Error.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openehealth.ipf.platform.camel.ihe.fhir.pharm5;
+
+import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ *
+ */
+public class TestPharm5Error extends AbstractTestPharm5 {
+
+    private static final String CONTEXT_DESCRIPTOR = "pharm-5-error.xml";
+
+    @BeforeAll
+    public static void setUpClass() {
+        startServer(CONTEXT_DESCRIPTOR);
+    }
+
+    @Test
+    void testSendManuallyReturningError() {
+        Assertions.assertThrows(InternalErrorException.class, () -> {
+            try {
+                sendManually(findMedicationTreatmentPlanParameters());
+            } catch (InternalErrorException e) {
+                assertAndRethrow(e, OperationOutcome.IssueType.PROCESSING);
+            }
+        });
+    }
+
+}

--- a/platform-camel/ihe/fhir/r4/mhd/src/test/resources/pharm-5-error.xml
+++ b/platform-camel/ihe/fhir/r4/mhd/src/test/resources/pharm-5-error.xml
@@ -1,0 +1,30 @@
+<!--
+  ~ Copyright 2022 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+http://www.springframework.org/schema/beans
+http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <import resource="common-fhir-beans.xml"/>
+
+    <bean id="routeBuilder"
+          class="org.openehealth.ipf.platform.camel.ihe.fhir.pharm5.Pharm5TestRouteBuilder">
+        <constructor-arg value="true"/>
+    </bean>
+
+</beans>

--- a/platform-camel/ihe/fhir/r4/mhd/src/test/resources/pharm-5.xml
+++ b/platform-camel/ihe/fhir/r4/mhd/src/test/resources/pharm-5.xml
@@ -1,0 +1,30 @@
+<!--
+  ~ Copyright 2022 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+http://www.springframework.org/schema/beans
+http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <import resource="common-fhir-beans.xml"/>
+
+    <bean id="routeBuilder"
+          class="org.openehealth.ipf.platform.camel.ihe.fhir.pharm5.Pharm5TestRouteBuilder">
+        <constructor-arg value="false"/>
+    </bean>
+
+</beans>


### PR DESCRIPTION
This PR implements the (MHD-based) CMPD [PHARM-5 transaction](https://www.ihe.net/uploadedFiles/Documents/Pharmacy/IHE_Pharmacy_Suppl_CMPD.pdf).

- [x] PHARM-5 consumer: working
- [x] PHARM-5 producer: working
- [x] Audit strategy: small issue with the destination in the Document Consumer audit message, the NetworkAccessPoint is missing
- [x] Create tests
- [x] Create documentation [(#5)](https://github.com/oehf/ipf-docs/pull/5)