### PR TITLE
Dependency upgrade and cleaning

### DIFF
--- a/commons/ihe/fhir/r4/core/src/test/java/org/openehealth/ipf/commons/ihe/fhir/support/translation/NamingSystemUriMapperJsonTest.java
+++ b/commons/ihe/fhir/r4/core/src/test/java/org/openehealth/ipf/commons/ihe/fhir/support/translation/NamingSystemUriMapperJsonTest.java
@@ -30,7 +30,7 @@ public class NamingSystemUriMapperJsonTest extends AbstractSystemUriMapperTest {
     protected UriMapper initMapper(DefaultNamingSystemServiceImpl namingSystemService) {
         namingSystemService.addNamingSystemsFromJson(
                 new InputStreamReader(getClass().getResourceAsStream("/namingsystems.json")));
-        return new NamingSystemUriMapper(namingSystemService, "identifiers");
+        return new NamingSystemUriMapper(namingSystemService, "Bundle/identifiers");
     }
 
 }

--- a/commons/ihe/fhir/r4/core/src/test/java/org/openehealth/ipf/commons/ihe/fhir/support/translation/NamingSystemUriMapperXmlTest.java
+++ b/commons/ihe/fhir/r4/core/src/test/java/org/openehealth/ipf/commons/ihe/fhir/support/translation/NamingSystemUriMapperXmlTest.java
@@ -30,7 +30,7 @@ public class NamingSystemUriMapperXmlTest extends AbstractSystemUriMapperTest {
     protected UriMapper initMapper(DefaultNamingSystemServiceImpl namingSystemService) {
         namingSystemService.addNamingSystemsFromXml(
                 new InputStreamReader(getClass().getResourceAsStream("/namingsystems.xml")));
-        return new NamingSystemUriMapper(namingSystemService, "identifiers");
+        return new NamingSystemUriMapper(namingSystemService, "Bundle/identifiers");
     }
 
 }

--- a/commons/ihe/fhir/stu3/core/src/test/java/org/openehealth/ipf/commons/ihe/fhir/support/translation/NamingSystemUriMapperJsonTest.java
+++ b/commons/ihe/fhir/stu3/core/src/test/java/org/openehealth/ipf/commons/ihe/fhir/support/translation/NamingSystemUriMapperJsonTest.java
@@ -30,7 +30,7 @@ public class NamingSystemUriMapperJsonTest extends AbstractSystemUriMapperTest {
     protected UriMapper initMapper(DefaultNamingSystemServiceImpl namingSystemService) {
         namingSystemService.addNamingSystemsFromJson(
                 new InputStreamReader(getClass().getResourceAsStream("/namingsystems.json")));
-        return new NamingSystemUriMapper(namingSystemService, "identifiers");
+        return new NamingSystemUriMapper(namingSystemService, "Bundle/identifiers");
     }
 
 }

--- a/commons/ihe/fhir/stu3/core/src/test/java/org/openehealth/ipf/commons/ihe/fhir/support/translation/NamingSystemUriMapperXmlTest.java
+++ b/commons/ihe/fhir/stu3/core/src/test/java/org/openehealth/ipf/commons/ihe/fhir/support/translation/NamingSystemUriMapperXmlTest.java
@@ -30,7 +30,7 @@ public class NamingSystemUriMapperXmlTest extends AbstractSystemUriMapperTest {
     protected UriMapper initMapper(DefaultNamingSystemServiceImpl namingSystemService) {
         namingSystemService.addNamingSystemsFromXml(
                 new InputStreamReader(getClass().getResourceAsStream("/namingsystems.xml")));
-        return new NamingSystemUriMapper(namingSystemService, "identifiers");
+        return new NamingSystemUriMapper(namingSystemService, "Bundle/identifiers");
     }
 
 }

--- a/commons/xml/src/main/java/org/openehealth/ipf/commons/xml/ClasspathResourceResolver.java
+++ b/commons/xml/src/main/java/org/openehealth/ipf/commons/xml/ClasspathResourceResolver.java
@@ -1,0 +1,52 @@
+package org.openehealth.ipf.commons.xml;
+
+import net.sf.saxon.lib.ResourceRequest;
+import net.sf.saxon.lib.ResourceResolver;
+import net.sf.saxon.trans.XPathException;
+import org.xml.sax.InputSource;
+
+import javax.xml.transform.Source;
+import javax.xml.transform.sax.SAXSource;
+import java.util.Objects;
+
+/**
+ * ResourceResolver used to correctly resolve import commands in xslt or xquery content. The referenced resource
+ * (stylesheet or document) can be found somewhere in the classloader's classpath. If it can't be found, the default
+ * ResourceResolver is used.
+ *
+ * @author Quentin Ligier
+ **/
+public class ClasspathResourceResolver implements ResourceResolver {
+
+    private final ResourceResolver standardResolver;
+
+    /**
+     * Constructor.
+     *
+     * @param resolver The standard resolver to use if the resource isn't found in the classpath.
+     */
+    public ClasspathResourceResolver(final ResourceResolver resolver) {
+        this.standardResolver = Objects.requireNonNull(resolver);
+    }
+
+    /**
+     * Resolve by searching the classpath, fallback to default resolution strategy.
+     *
+     * @param resourceRequest The SAXON resource request.
+     * @return the resource {@link Source}.
+     * @throws XPathException if the request is invalid in some way, or if the identified resource is unsuitable,
+     * or if resolution is to fail rather than being delegated to another resolver.
+     */
+    @Override
+    public Source resolve(final ResourceRequest resourceRequest) throws XPathException {
+        final var url = getClass().getClassLoader().getResource(resourceRequest.relativeUri);
+        if (url != null) {
+            var saxSource = new SAXSource();
+            saxSource.setInputSource(new InputSource(url.toString()));
+            saxSource.setSystemId(url.toString());
+            return saxSource;
+        } else {
+            return standardResolver.resolve(resourceRequest);
+        }
+    }
+}

--- a/commons/xml/src/main/java/org/openehealth/ipf/commons/xml/ClasspathUriResolver.java
+++ b/commons/xml/src/main/java/org/openehealth/ipf/commons/xml/ClasspathUriResolver.java
@@ -19,8 +19,13 @@ import javax.xml.transform.Source;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.URIResolver;
 import javax.xml.transform.sax.SAXSource;
+import javax.xml.transform.stream.StreamSource;
 
 import org.xml.sax.InputSource;
+
+import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 /**
  * URIResolver used to correctly resolve import commands in xslt or xquery
@@ -53,9 +58,18 @@ class ClasspathUriResolver implements URIResolver {
             saxSource.setInputSource(new InputSource(url.toString()));
             saxSource.setSystemId(url.toString());
             return saxSource;
-        } else {
+        } else if (standardResolver != null) {
             return standardResolver.resolve(href, base);
+        } else if (href != null && base != null) {
+            final URI baseUri;
+            try {
+                baseUri = new URI(base);
+            } catch (final URISyntaxException e) {
+                return null;
+            }
+            return new StreamSource(new File(baseUri.resolve(href)));
         }
+        return null;
     }
 
 }

--- a/commons/xml/src/main/java/org/openehealth/ipf/commons/xml/ClasspathUriResolver.java
+++ b/commons/xml/src/main/java/org/openehealth/ipf/commons/xml/ClasspathUriResolver.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2009 the original author or authors.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *     
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,55 +21,41 @@ import javax.xml.transform.URIResolver;
 import javax.xml.transform.sax.SAXSource;
 import javax.xml.transform.stream.StreamSource;
 
-import org.xml.sax.InputSource;
-
-import java.io.File;
-import java.net.URI;
-import java.net.URISyntaxException;
-
 /**
- * URIResolver used to correctly resolve import commands in xslt or xquery
- * content. The referenced resource (stylesheet or document) can be found
- * somewhere in the classloader's classpath. If it can't be found, the default
- * URIResolver is used.
- * 
+ * URIResolver used to correctly resolve import commands in xslt or xquery content. The referenced resource (stylesheet
+ * or document) can be found somewhere in the classloader's classpath. If it can't be found, the default URIResolver is
+ * used.
+ *
  * @author Christian Ohr
  */
 class ClasspathUriResolver implements URIResolver {
 
     private final URIResolver standardResolver;
-    
+
     public ClasspathUriResolver(URIResolver resolver) {
         super();
         standardResolver = resolver;
     }
 
     /**
-     * Resolve by searching the classpath, fallback to default resolution
-     * strategy.
-     * 
+     * Resolve by searching the classpath, fallback to default resolution strategy.
+     * <p>
+     * Avoid using {@link SAXSource} because Saxon's {@link net.sf.saxon.lib.EntityResolverWrappingResourceResolver}
+     * doesn't support it.
      */
     @Override
     public Source resolve(String href, String base) throws TransformerException {
-        var cl = getClass().getClassLoader();
-        var url = cl.getResource(href);
-        if (url != null) {
-            var saxSource = new SAXSource();
-            saxSource.setInputSource(new InputSource(url.toString()));
-            saxSource.setSystemId(url.toString());
-            return saxSource;
-        } else if (standardResolver != null) {
-            return standardResolver.resolve(href, base);
-        } else if (href != null && base != null) {
-            final URI baseUri;
-            try {
-                baseUri = new URI(base);
-            } catch (final URISyntaxException e) {
-                return null;
+        final var inputStream = getClass().getClassLoader().getResourceAsStream(href);
+        if (inputStream != null) {
+            return new StreamSource(inputStream);
+        } else {
+            final var source = standardResolver.resolve(href, base);
+            if (source instanceof SAXSource) {
+                return new StreamSource(((SAXSource) source).getInputSource().getByteStream());
+            } else {
+                return source;
             }
-            return new StreamSource(new File(baseUri.resolve(href)));
         }
-        return null;
     }
 
 }

--- a/commons/xml/src/main/java/org/openehealth/ipf/commons/xml/XqjTransmogrifier.java
+++ b/commons/xml/src/main/java/org/openehealth/ipf/commons/xml/XqjTransmogrifier.java
@@ -48,7 +48,7 @@ public class XqjTransmogrifier<T> extends AbstractCachingXmlProcessor<XQPrepared
     private static final SaxonXQDataSource DATA_SOURCE;
     static {
         XQUERY_GLOBAL_CONFIG = new Configuration();
-        XQUERY_GLOBAL_CONFIG.setURIResolver(new ClasspathUriResolver(XQUERY_GLOBAL_CONFIG.getURIResolver()));
+        XQUERY_GLOBAL_CONFIG.setResourceResolver(new ClasspathResourceResolver(XQUERY_GLOBAL_CONFIG.getResourceResolver()));
         DATA_SOURCE = new SaxonXQDataSource(XQUERY_GLOBAL_CONFIG);
     }
 

--- a/commons/xml/src/main/java/org/openehealth/ipf/commons/xml/XsltTransmogrifier.java
+++ b/commons/xml/src/main/java/org/openehealth/ipf/commons/xml/XsltTransmogrifier.java
@@ -17,6 +17,7 @@ package org.openehealth.ipf.commons.xml;
 
 import lombok.Getter;
 import lombok.Setter;
+import net.sf.saxon.lib.StandardURIResolver;
 import org.openehealth.ipf.commons.core.modules.api.Transmogrifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -88,8 +89,12 @@ public class XsltTransmogrifier<T> extends AbstractCachingXmlProcessor<Templates
     {
         super(classLoader);
         factory = TransformerFactory.newInstance();
-        // Wrap the default resolver
-        resolver = new ClasspathUriResolver(factory.getURIResolver());
+        // Wrap the default resolver if available
+        if (factory.getURIResolver() != null) {
+            resolver = new ClasspathUriResolver(factory.getURIResolver());
+        } else {
+            resolver = new ClasspathUriResolver(new StandardURIResolver());
+        }
         factory.setURIResolver(resolver);
         this.outputFormat = outputFormat;
         this.staticParams = staticParams;

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -29,7 +29,7 @@
         <ph-commons-version>9.5.5</ph-commons-version>
         <saxon-he-version>11.4</saxon-he-version>
         <simple-syslog-version>0.0.16</simple-syslog-version>
-        <spring-boot-version>2.6.8</spring-boot-version>
+        <spring-boot-version>2.7.3</spring-boot-version>
         <vertx-version>4.3.4</vertx-version>
         <vibur-version>25.0</vibur-version>
         <xmlsec-version>2.3.2</xmlsec-version>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -17,7 +17,7 @@
         <gazelle-hl7v3-jar-version>1.3.7</gazelle-hl7v3-jar-version>
         <groovy-version>3.0.13</groovy-version>
         <hapi-version>2.3</hapi-version>
-        <hapi-fhir-version>5.7.2</hapi-fhir-version>
+        <hapi-fhir-version>6.1.2</hapi-fhir-version>
         <herasaf-version>2.0.4</herasaf-version>
         <ipf-gazelle-version>2.1.0</ipf-gazelle-version>
         <ipf-oht-mdht-version>1.2.0.201212201425</ipf-oht-mdht-version>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -9,13 +9,13 @@
 
     <properties>
         <gpg-plugin-version>1.6</gpg-plugin-version>
-        <bouncycastle-version>1.71</bouncycastle-version>
-        <brave-version>5.13.8</brave-version>
+        <bouncycastle-version>1.72</bouncycastle-version>
+        <brave-version>5.14.1</brave-version>
         <camel-version>3.14.4</camel-version>
         <cxf-version>3.5.2</cxf-version>
         <commons-io-version>2.11.0</commons-io-version>
         <gazelle-hl7v3-jar-version>1.3.7</gazelle-hl7v3-jar-version>
-        <groovy-version>3.0.10</groovy-version>
+        <groovy-version>3.0.13</groovy-version>
         <hapi-version>2.3</hapi-version>
         <hapi-fhir-version>5.7.2</hapi-fhir-version>
         <herasaf-version>2.0.4</herasaf-version>
@@ -30,7 +30,7 @@
         <saxon-he-version>11.4</saxon-he-version>
         <simple-syslog-version>0.0.16</simple-syslog-version>
         <spring-boot-version>2.6.8</spring-boot-version>
-        <vertx-version>3.9.13</vertx-version>
+        <vertx-version>4.3.4</vertx-version>
         <vibur-version>25.0</vibur-version>
         <xmlsec-version>2.3.0</xmlsec-version>
         <woodstox-version>6.2.8</woodstox-version>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -32,7 +32,7 @@
         <spring-boot-version>2.6.8</spring-boot-version>
         <vertx-version>4.3.4</vertx-version>
         <vibur-version>25.0</vibur-version>
-        <xmlsec-version>2.3.0</xmlsec-version>
+        <xmlsec-version>2.3.2</xmlsec-version>
         <woodstox-version>6.2.8</woodstox-version>
     </properties>
 

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -27,7 +27,7 @@
         <methanol-version>1.7.0</methanol-version>
         <ph-schematron-version>5.6.5</ph-schematron-version>
         <ph-commons-version>9.5.5</ph-commons-version>
-        <saxon-he-version>10.8</saxon-he-version>
+        <saxon-he-version>11.4</saxon-he-version>
         <simple-syslog-version>0.0.16</simple-syslog-version>
         <spring-boot-version>2.6.8</spring-boot-version>
         <vertx-version>3.9.13</vertx-version>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -11,7 +11,7 @@
         <gpg-plugin-version>1.6</gpg-plugin-version>
         <bouncycastle-version>1.72</bouncycastle-version>
         <brave-version>5.14.1</brave-version>
-        <camel-version>3.14.4</camel-version>
+        <camel-version>3.18.2</camel-version>
         <cxf-version>3.5.2</cxf-version>
         <commons-io-version>2.11.0</commons-io-version>
         <gazelle-hl7v3-jar-version>1.3.7</gazelle-hl7v3-jar-version>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -58,11 +58,40 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
+                <groupId>ca.uhn.hapi.fhir</groupId>
+                <artifactId>hapi-fhir-validation</artifactId>
+                <version>${hapi-fhir-version}</version>
+                <exclusions>
+                    <exclusion>
+                        <!-- A newer version is imported by Guava -->
+                        <groupId>com.google.errorprone</groupId>
+                        <artifactId>error_prone_annotations</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-bom</artifactId>
                 <version>${cxf-version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.cxf</groupId>
+                <artifactId>cxf-rt-ws-security</artifactId>
+                <version>${cxf-version}</version>
+                <exclusions>
+                    <exclusion>
+                        <!-- A newer version is imported by cxf-rt-ws-policy -->
+                        <groupId>org.apache.neethi</groupId>
+                        <artifactId>neethi</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <!-- A newer version is imported by IPF -->
+                        <groupId>org.bouncycastle</groupId>
+                        <artifactId>bcprov-jdk15on</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>

--- a/platform-camel/core/src/main/java/org/openehealth/ipf/platform/camel/core/config/CustomRouteBuilderConfigurer.java
+++ b/platform-camel/core/src/main/java/org/openehealth/ipf/platform/camel/core/config/CustomRouteBuilderConfigurer.java
@@ -58,10 +58,10 @@ public class CustomRouteBuilderConfigurer<R extends Registry> extends OrderedCon
     public void configure(CustomRouteBuilder customRouteBuilder) throws Exception{
         if (customRouteBuilder.getIntercepted() != null) {
             var intercepted = customRouteBuilder.getIntercepted();
-            customRouteBuilder.setContext(camelContext);
+            customRouteBuilder.setCamelContext(camelContext);
             customRouteBuilder.setRouteCollection(intercepted.getRouteCollection());
             customRouteBuilder.setRestCollection(intercepted.getRestCollection());
-            customRouteBuilder.setErrorHandlerBuilder(intercepted.getErrorHandlerBuilder());
+            customRouteBuilder.errorHandler(intercepted.getErrorHandlerFactory());
 
             // must invoke configure on the original builder so it adds its configuration to me
             customRouteBuilder.configure();

--- a/platform-camel/ihe/fhir/r4/mhd/pom.xml
+++ b/platform-camel/ihe/fhir/r4/mhd/pom.xml
@@ -49,6 +49,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-http-base</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.openehealth.ipf.commons</groupId>
             <artifactId>ipf-commons-spring</artifactId>
             <scope>test</scope>

--- a/platform-camel/ihe/fhir/r4/mhd/src/test/java/org/openehealth/ipf/platform/camel/ihe/fhir/iti68/TestIti68Error.java
+++ b/platform-camel/ihe/fhir/r4/mhd/src/test/java/org/openehealth/ipf/platform/camel/ihe/fhir/iti68/TestIti68Error.java
@@ -17,7 +17,7 @@
 package org.openehealth.ipf.platform.camel.ihe.fhir.iti68;
 
 import org.apache.camel.CamelExecutionException;
-import org.apache.camel.http.common.HttpOperationFailedException;
+import org.apache.camel.http.base.HttpOperationFailedException;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.openehealth.ipf.commons.audit.codes.EventOutcomeIndicator;

--- a/platform-camel/ihe/fhir/r4/pixpdq/src/test/resources/common-fhir-beans.xml
+++ b/platform-camel/ihe/fhir/r4/pixpdq/src/test/resources/common-fhir-beans.xml
@@ -52,7 +52,7 @@ http://openehealth.org/schema/ipf-commons-core.xsd">
 
     <bean id="uriMapper" class="org.openehealth.ipf.commons.ihe.fhir.support.translation.NamingSystemUriMapper">
         <constructor-arg ref="namingSystemService"/>
-        <constructor-arg value="identifiers"/>
+        <constructor-arg value="Bundle/identifiers"/>
     </bean>
 
     <!-- Set dummy context -->

--- a/platform-camel/ihe/fhir/r4/qedm/pom.xml
+++ b/platform-camel/ihe/fhir/r4/qedm/pom.xml
@@ -77,16 +77,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.helger</groupId>
-            <artifactId>ph-schematron</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.helger</groupId>
-            <artifactId>ph-commons</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-http</artifactId>
             <scope>test</scope>

--- a/platform-camel/ihe/fhir/stu3/mhd/src/test/java/org/openehealth/ipf/platform/camel/ihe/fhir/iti68/TestIti68Error.java
+++ b/platform-camel/ihe/fhir/stu3/mhd/src/test/java/org/openehealth/ipf/platform/camel/ihe/fhir/iti68/TestIti68Error.java
@@ -17,7 +17,7 @@
 package org.openehealth.ipf.platform.camel.ihe.fhir.iti68;
 
 import org.apache.camel.CamelExecutionException;
-import org.apache.camel.http.common.HttpOperationFailedException;
+import org.apache.camel.http.base.HttpOperationFailedException;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.openehealth.ipf.commons.audit.codes.EventOutcomeIndicator;

--- a/platform-camel/ihe/fhir/stu3/pixpdq/src/test/resources/common-fhir-beans.xml
+++ b/platform-camel/ihe/fhir/stu3/pixpdq/src/test/resources/common-fhir-beans.xml
@@ -52,7 +52,7 @@ http://openehealth.org/schema/ipf-commons-core.xsd">
 
     <bean id="uriMapper" class="org.openehealth.ipf.commons.ihe.fhir.support.translation.NamingSystemUriMapper">
         <constructor-arg ref="namingSystemService"/>
-        <constructor-arg value="identifiers"/>
+        <constructor-arg value="Bundle/identifiers"/>
     </bean>
 
     <!-- Set dummy context -->

--- a/platform-camel/ihe/fhir/stu3/qedm/pom.xml
+++ b/platform-camel/ihe/fhir/stu3/qedm/pom.xml
@@ -70,16 +70,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.helger</groupId>
-            <artifactId>ph-schematron</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.helger</groupId>
-            <artifactId>ph-commons</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-http</artifactId>
             <scope>test</scope>

--- a/platform-camel/ihe/hpd/pom.xml
+++ b/platform-camel/ihe/hpd/pom.xml
@@ -140,7 +140,7 @@
 
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-cxf</artifactId>
+            <artifactId>camel-cxf-spring-soap</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/platform-camel/ihe/xacml20/pom.xml
+++ b/platform-camel/ihe/xacml20/pom.xml
@@ -101,7 +101,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-cxf</artifactId>
+            <artifactId>camel-cxf-spring-soap</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/platform-camel/ihe/xds/pom.xml
+++ b/platform-camel/ihe/xds/pom.xml
@@ -138,10 +138,9 @@
             <scope>test</scope>
         </dependency>
 
-
         <dependency>
             <groupId>org.apache.camel</groupId>
-            <artifactId>camel-cxf</artifactId>
+            <artifactId>camel-cxf-spring-soap</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/platform-camel/ihe/xds/src/test/resources/dispatch/dispatch-test-context.xml
+++ b/platform-camel/ihe/xds/src/test/resources/dispatch/dispatch-test-context.xml
@@ -17,14 +17,14 @@
        xmlns:ihe="urn:ihe:iti:xds-b:2007"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:camel="http://camel.apache.org/schema/spring"
-       xmlns:cxf="http://camel.apache.org/schema/cxf"
+       xmlns:cxf="http://camel.apache.org/schema/cxf/jaxws"
        xsi:schemaLocation="
 http://www.springframework.org/schema/beans
 http://www.springframework.org/schema/beans/spring-beans.xsd
 http://camel.apache.org/schema/spring 
 http://camel.apache.org/schema/spring/camel-spring.xsd
-http://camel.apache.org/schema/cxf
-http://camel.apache.org/schema/cxf/camel-cxf.xsd
+http://camel.apache.org/schema/cxf/jaxws
+http://camel.apache.org/schema/cxf/jaxws/camel-cxf.xsd
 ">
 
     <import resource="../common-xds-beans.xml"/>

--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <surefire-plugin-version>2.22.2</surefire-plugin-version>
-        <jxr-plugin-version>2.5</jxr-plugin-version>
-        <project-info-reports-plugin-version>3.0.0</project-info-reports-plugin-version>
+        <jxr-plugin-version>3.3.0</jxr-plugin-version>
+        <project-info-reports-plugin-version>3.4.1</project-info-reports-plugin-version>
         <maven-dsldoc-plugin-version>1.6</maven-dsldoc-plugin-version>
         <maven-changes-plugin-version>2.12.1</maven-changes-plugin-version>
 
@@ -44,14 +44,14 @@
         <gmavenplus-plugin-version>1.13.1</gmavenplus-plugin-version>
 
         <jar-plugin-version>3.2.2</jar-plugin-version>
-        <javadoc-plugin-version>3.2.0</javadoc-plugin-version>
+        <javadoc-plugin-version>3.4.1</javadoc-plugin-version>
         <jaxb-plugin-version>2.5.0</jaxb-plugin-version>
         <lombok-plugin-version>1.18.20.0</lombok-plugin-version>
-        <nexus-staging-plugin-version>1.6.8</nexus-staging-plugin-version>
+        <nexus-staging-plugin-version>1.6.13</nexus-staging-plugin-version>
         <release-plugin-version>2.5.3</release-plugin-version>
-        <resources-plugin-version>3.2.0</resources-plugin-version>
+        <resources-plugin-version>3.3.0</resources-plugin-version>
         <sources-plugin-version>3.2.1</sources-plugin-version>
-        <site-plugin-version>3.9.1</site-plugin-version>
+        <site-plugin-version>3.12.1</site-plugin-version>
 
         <!-- Dependency version properties -->
         <awaitility-version>4.1.1</awaitility-version>

--- a/pom.xml
+++ b/pom.xml
@@ -263,6 +263,21 @@
                         <groupId>commons-logging</groupId>
                         <artifactId>commons-logging</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <!-- A newer version is imported by wss4j -->
+                        <groupId>joda-time</groupId>
+                        <artifactId>joda-time</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <!-- A newer version is imported by cxf-rt-frontend-jaxws -->
+                        <groupId>org.ow2.asm</groupId>
+                        <artifactId>asm</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <!-- A newer version is imported by IPF -->
+                        <groupId>org.bouncycastle</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>


### PR DESCRIPTION
- Upgrade Saxon to 11.4
- Upgrade HAPI FHIR to 6.1.2
- Upgrade Camel to 3.18.2
- Upgrade Spring Boot to 2.7.3
- Upgrade other dependencies and plugins
- Remove ph-schematron and ph-commons from Camel QEDM modules
- Deduplicate dependencies

As discussed in #395