### PR TITLE
Normalize text of ParticipantObjectQuery in DICOM audit parser

### DIFF
--- a/commons/audit/src/main/java/org/openehealth/ipf/commons/audit/unmarshal/dicom/DICOMAuditParser.java
+++ b/commons/audit/src/main/java/org/openehealth/ipf/commons/audit/unmarshal/dicom/DICOMAuditParser.java
@@ -166,7 +166,7 @@ public class DICOMAuditParser implements AuditParser {
         poi.setParticipantObjectSensitivity(element.getAttributeValue(PARTICIPANT_OBJECT_SENSITIVITY));
         poi.setParticipantObjectName(element.getChildText(PARTICIPANT_OBJECT_NAME));
         if (element.getChild(PARTICIPANT_OBJECT_QUERY) != null) {
-            poi.setParticipantObjectQuery(Base64.getDecoder().decode(element.getChildText(PARTICIPANT_OBJECT_QUERY)));
+            poi.setParticipantObjectQuery(Base64.getDecoder().decode(element.getChildTextTrim(PARTICIPANT_OBJECT_QUERY)));
         }
         mapInto(poi.getParticipantObjectDetails(), element, PARTICIPANT_OBJECT_DETAIL, this::valuePair);
         mapInto(poi.getParticipantObjectDescriptions(), element, PARTICIPANT_OBJECT_DESCRIPTION, this::partipantObjectDescription);


### PR DESCRIPTION
In DICOM audit messages, ParticipantObjectQuery is a xsd:base64Binary, which collapses whitespaces. When reading it, we should normalize the value before trying to base64-decode it.

Currently, it fails if the XML is indented: 
```xml
<ParticipantObjectQuery>
    VVRGLTg=
</ParticipantObjectQuery>
```

We can use getChildTextTrim instead of getChildTextNormalize, because whitespaces are not allowed inside the base64 content, so there's no point in normalizing them. 