### PR TITLE
#465: fix the IHE CodeSystem mapping in ATNA->FHIR translation

### DIFF
--- a/commons/ihe/fhir/r4/audit/src/main/resources/META-INF/map/atna2fhir.map
+++ b/commons/ihe/fhir/r4/audit/src/main/resources/META-INF/map/atna2fhir.map
@@ -2,7 +2,7 @@ mappings = {
 
     atnaCodingSystem(
         'DCM'               : 'http://dicom.nema.org/resources/ontology/DCM',
-        'IHE Transactions'  : 'urn:oid:1.3.6.1.4.1.19376',
+        'IHE Transactions'  : 'urn:ihe:event-type-code',
         'IHE XDS Metadata'  : 'urn:oid:1.3.6.1.4.1.19376.1.2.6',
         'RFC-3881'          : 'urn:ietf:rfc:3881',
         (ELSE)              : { (it && it.charAt(0).isDigit()) ? 'urn:oid:' + it : it },


### PR DESCRIPTION
Small fix on top of 2997f8a826ecbc2fdcd42999ab9eca6e5ed47d48: I found the URN defined by IHE for the transactions: `urn:ihe:event-type-code`.
It's defined on the [ITI Vocabulary Registry and Data Dictionary](https://wiki.ihe.net/index.php/ITI_Vocabulary_Registry_and_Data_Dictionary) page and was discussed on the [Google Groups](https://groups.google.com/g/ihe-mhd-implementors/c/cyZR_D5I7iw).

Fixes #465.