### PR TITLE
Uniformize mapping of ATNA->FHIR translation

### DIFF
--- a/commons/audit/src/main/java/org/openehealth/ipf/commons/audit/codes/ActiveParticipantRoleIdCode.java
+++ b/commons/audit/src/main/java/org/openehealth/ipf/commons/audit/codes/ActiveParticipantRoleIdCode.java
@@ -51,7 +51,7 @@ public enum ActiveParticipantRoleIdCode implements ActiveParticipantRoleId, Enum
     private final ActiveParticipantRoleId value;
 
     ActiveParticipantRoleIdCode(String code, String displayName) {
-        this.value = ActiveParticipantRoleId.of(code, "DCM", displayName);
+        this.value = ActiveParticipantRoleId.of(code, CODE_SYSTEM_NAME_DCM, displayName);
     }
 
     public static ActiveParticipantRoleIdCode enumForCode(String code) {

--- a/commons/audit/src/main/java/org/openehealth/ipf/commons/audit/codes/AuditSourceType.java
+++ b/commons/audit/src/main/java/org/openehealth/ipf/commons/audit/codes/AuditSourceType.java
@@ -44,7 +44,7 @@ public enum AuditSourceType implements EnumeratedCodedValue<AuditSource>, AuditS
     private final AuditSource value;
 
     AuditSourceType(String code, String displayName) {
-        this.value = AuditSource.of(code, "DCM", displayName);
+        this.value = AuditSource.of(code, CODE_SYSTEM_NAME_DCM, displayName);
     }
 
     public static AuditSourceType enumForCode(String code) {

--- a/commons/audit/src/main/java/org/openehealth/ipf/commons/audit/codes/EventIdCode.java
+++ b/commons/audit/src/main/java/org/openehealth/ipf/commons/audit/codes/EventIdCode.java
@@ -51,7 +51,7 @@ public enum EventIdCode implements EventId, EnumeratedCodedValue<EventId> {
     private final EventId value;
 
     EventIdCode(String code, String displayName) {
-        this.value = EventId.of(code, "DCM", displayName);
+        this.value = EventId.of(code, CODE_SYSTEM_NAME_DCM, displayName);
     }
 
     public static EventIdCode enumForCode(String code) {

--- a/commons/audit/src/main/java/org/openehealth/ipf/commons/audit/codes/EventTypeCode.java
+++ b/commons/audit/src/main/java/org/openehealth/ipf/commons/audit/codes/EventTypeCode.java
@@ -70,7 +70,7 @@ public enum EventTypeCode implements EventType, EnumeratedCodedValue<EventType> 
     private final EventType value;
 
     EventTypeCode(String code, String displayName) {
-        this.value = EventType.of(code, "DCM", displayName);
+        this.value = EventType.of(code, CODE_SYSTEM_NAME_DCM, displayName);
     }
 
     public static EventTypeCode enumForCode(String code) {

--- a/commons/audit/src/main/java/org/openehealth/ipf/commons/audit/codes/MediaTypeCode.java
+++ b/commons/audit/src/main/java/org/openehealth/ipf/commons/audit/codes/MediaTypeCode.java
@@ -47,7 +47,7 @@ public enum MediaTypeCode implements MediaType, EnumeratedCodedValue<MediaType> 
     private final MediaType value;
 
     MediaTypeCode(String code, String displayName) {
-        this.value = MediaType.of(code, "DCM", displayName);
+        this.value = MediaType.of(code, CODE_SYSTEM_NAME_DCM, displayName);
     }
 
     public static MediaTypeCode enumForCode(String code) {

--- a/commons/audit/src/main/java/org/openehealth/ipf/commons/audit/codes/ParticipantObjectIdTypeCode.java
+++ b/commons/audit/src/main/java/org/openehealth/ipf/commons/audit/codes/ParticipantObjectIdTypeCode.java
@@ -46,9 +46,9 @@ public enum ParticipantObjectIdTypeCode implements ParticipantObjectIdType, Enum
     URI("12", "URI", "RFC-3881"),
 
     // DCM
-    StudyInstanceUID("110180", "Study Instance UID", "DCM"),
-    SOPClassUID("110181", "SOP Class UID", "DCM"),
-    NodeID("110182", "Node ID", "DCM"),
+    StudyInstanceUID("110180", "Study Instance UID", CODE_SYSTEM_NAME_DCM),
+    SOPClassUID("110181", "SOP Class UID", CODE_SYSTEM_NAME_DCM),
+    NodeID("110182", "Node ID", CODE_SYSTEM_NAME_DCM),
 
     // IHE
     XdsMetadata("urn:uuid:a54d6aa5-d40d-43f9-88c5-b4633d873bdd", "submission set classificationNode", "IHE XDS Metadata");

--- a/commons/audit/src/main/java/org/openehealth/ipf/commons/audit/types/CodedValueType.java
+++ b/commons/audit/src/main/java/org/openehealth/ipf/commons/audit/types/CodedValueType.java
@@ -23,6 +23,10 @@ import java.io.Serializable;
  */
 public interface CodedValueType extends Serializable {
 
+    String CODE_SYSTEM_NAME_IHE_TRANSACTIONS = "IHE Transactions";
+    String CODE_SYSTEM_NAME_DCM = "DCM";
+    String CODE_SYSTEM_NAME_EHS = "e-health-suisse";
+
     String getCode();
 
     String getOriginalText();

--- a/commons/ihe/fhir/core/src/main/java/org/openehealth/ipf/commons/ihe/fhir/audit/codes/Constants.java
+++ b/commons/ihe/fhir/core/src/main/java/org/openehealth/ipf/commons/ihe/fhir/audit/codes/Constants.java
@@ -19,7 +19,7 @@ package org.openehealth.ipf.commons.ihe.fhir.audit.codes;
 public class Constants {
 
     public static final String IHE_SYSTEM_NAME = "urn:ihe:event-type-code";
-    public static final String EHS_SYSTEM_NAME = "e-health-suisse";
+    public static final String EHS_SYSTEM_NAME = "urn:e-health-suisse:event-type-code";
 
     public static final String DCM_SYSTEM_NAME = "http://dicom.nema.org/resources/ontology/DCM";
     public static final String DCM_OCLIENT_CODE = "110150";

--- a/commons/ihe/fhir/r4/audit/src/main/groovy/org/openehealth/ipf/commons/ihe/fhir/atna/translation/AuditRecordTranslator.groovy
+++ b/commons/ihe/fhir/r4/audit/src/main/groovy/org/openehealth/ipf/commons/ihe/fhir/atna/translation/AuditRecordTranslator.groovy
@@ -82,7 +82,7 @@ class AuditRecordTranslator implements ToFhirTranslator<AuditMessage> {
 
     static AuditEvent.AuditEventAgentComponent participant(ActiveParticipantType atna) {
         AuditEvent.AuditEventAgentComponent fhir = new AuditEvent.AuditEventAgentComponent(new BooleanType(atna.userIsRequestor))
-        atna.roleIDCodes.each { fhir.addRole(codeableConcept(it)) }
+        fhir.setType(codeableConcept(atna.roleIDCodes.first()))
         fhir.who = new Reference(identifier: new Identifier(value: atna.userID))
         fhir.altId = atna.alternativeUserID
         fhir.name = atna.userName

--- a/commons/ihe/fhir/r4/core/src/main/java/org/openehealth/ipf/commons/ihe/fhir/support/audit/marshal/AbstractFhirAuditSerializationStrategy.java
+++ b/commons/ihe/fhir/r4/core/src/main/java/org/openehealth/ipf/commons/ihe/fhir/support/audit/marshal/AbstractFhirAuditSerializationStrategy.java
@@ -50,6 +50,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.openehealth.ipf.commons.audit.types.CodedValueType.CODE_SYSTEM_NAME_EHS;
 import static org.openehealth.ipf.commons.audit.types.CodedValueType.CODE_SYSTEM_NAME_IHE_TRANSACTIONS;
 import static org.openehealth.ipf.commons.ihe.fhir.audit.codes.Constants.*;
 
@@ -89,6 +90,8 @@ abstract class AbstractFhirAuditSerializationStrategy implements SerializationSt
         eit.getEventTypeCode().forEach(etc -> {
             if (CODE_SYSTEM_NAME_IHE_TRANSACTIONS.equals(etc.getCodeSystemName())) {
                 auditEvent.addSubtype(codedValueTypeToCoding(etc, IHE_SYSTEM_NAME));
+            } else if (CODE_SYSTEM_NAME_EHS.equals(etc.getCodeSystemName())) {
+                auditEvent.addSubtype(codedValueTypeToCoding(etc, EHS_SYSTEM_NAME));
             } else {
                 auditEvent.addSubtype(codedValueTypeToCoding(etc));
             }

--- a/commons/ihe/fhir/r4/core/src/main/java/org/openehealth/ipf/commons/ihe/fhir/support/audit/marshal/AbstractFhirAuditSerializationStrategy.java
+++ b/commons/ihe/fhir/r4/core/src/main/java/org/openehealth/ipf/commons/ihe/fhir/support/audit/marshal/AbstractFhirAuditSerializationStrategy.java
@@ -125,17 +125,13 @@ abstract class AbstractFhirAuditSerializationStrategy implements SerializationSt
                 .setType(tvp.getType())
                 .setValue(new Base64BinaryType(tvp.getValue()))));
         if (isNotBlank(poit.getParticipantObjectID())) {
-            if (poit.getParticipantObjectTypeCodeRole() == ParticipantObjectTypeCodeRole.Patient) {
-                var patReference = new Reference(poit.getParticipantObjectID());
-                if (patReference.getReferenceElement().hasResourceType()) {
-                    entity.setWhat(new Reference(poit.getParticipantObjectID()));
-                } else {
-                    entity.setWhat(new Reference().setIdentifier(
-                        new Identifier().setValue(poit.getParticipantObjectID())));
-                }
+            var whatReference = new Reference(poit.getParticipantObjectID());
+            if (whatReference.getReferenceElement().hasResourceType()) {
+                // participantObjectID is a FHIR resource reference, let's use it
+                entity.setWhat(whatReference);
             } else {
-                final var reference = new Reference().setDisplay(poit.getParticipantObjectID());
-                entity.setWhat(reference);
+                entity.setWhat(new Reference().setIdentifier(
+                    new Identifier().setValue(poit.getParticipantObjectID())));
             }
         }
         return entity;

--- a/commons/ihe/fhir/r4/core/src/main/java/org/openehealth/ipf/commons/ihe/fhir/support/audit/marshal/AbstractFhirAuditSerializationStrategy.java
+++ b/commons/ihe/fhir/r4/core/src/main/java/org/openehealth/ipf/commons/ihe/fhir/support/audit/marshal/AbstractFhirAuditSerializationStrategy.java
@@ -50,6 +50,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.openehealth.ipf.commons.audit.types.CodedValueType.CODE_SYSTEM_NAME_IHE_TRANSACTIONS;
 import static org.openehealth.ipf.commons.ihe.fhir.audit.codes.Constants.*;
 
 /**
@@ -86,7 +87,7 @@ abstract class AbstractFhirAuditSerializationStrategy implements SerializationSt
             .setOutcome(getAuditEventOutcome(eit.getEventOutcomeIndicator()))
             .setOutcomeDesc(eit.getEventOutcomeDescription());
         eit.getEventTypeCode().forEach(etc -> {
-            if ("IHE Transactions".equals(etc.getCodeSystemName())) {
+            if (CODE_SYSTEM_NAME_IHE_TRANSACTIONS.equals(etc.getCodeSystemName())) {
                 auditEvent.addSubtype(codedValueTypeToCoding(etc, IHE_SYSTEM_NAME));
             } else {
                 auditEvent.addSubtype(codedValueTypeToCoding(etc));

--- a/commons/ihe/fhir/r4/core/src/main/java/org/openehealth/ipf/commons/ihe/fhir/support/audit/marshal/AbstractFhirAuditSerializationStrategy.java
+++ b/commons/ihe/fhir/r4/core/src/main/java/org/openehealth/ipf/commons/ihe/fhir/support/audit/marshal/AbstractFhirAuditSerializationStrategy.java
@@ -120,14 +120,18 @@ abstract class AbstractFhirAuditSerializationStrategy implements SerializationSt
             entity.addDetail(new AuditEvent.AuditEventEntityDetailComponent()
                 .setType(tvp.getType())
                 .setValue(new Base64BinaryType(tvp.getValue()))));
-        if (poit.getParticipantObjectTypeCodeRole() == ParticipantObjectTypeCodeRole.Patient &&
-            isNotBlank(poit.getParticipantObjectID())) {
-            var patReference = new Reference(poit.getParticipantObjectID());
-            if (patReference.getReferenceElement().hasResourceType()) {
-                entity.setWhat(new Reference(poit.getParticipantObjectID()));
+        if (isNotBlank(poit.getParticipantObjectID())) {
+            if (poit.getParticipantObjectTypeCodeRole() == ParticipantObjectTypeCodeRole.Patient) {
+                var patReference = new Reference(poit.getParticipantObjectID());
+                if (patReference.getReferenceElement().hasResourceType()) {
+                    entity.setWhat(new Reference(poit.getParticipantObjectID()));
+                } else {
+                    entity.setWhat(new Reference().setIdentifier(
+                        new Identifier().setValue(poit.getParticipantObjectID())));
+                }
             } else {
-                entity.setWhat(new Reference().setIdentifier(
-                    new Identifier().setValue(poit.getParticipantObjectID())));
+                final var reference = new Reference().setDisplay(poit.getParticipantObjectID());
+                entity.setWhat(reference);
             }
         }
         return entity;

--- a/commons/ihe/fhir/r4/core/src/main/java/org/openehealth/ipf/commons/ihe/fhir/support/audit/marshal/AbstractFhirAuditSerializationStrategy.java
+++ b/commons/ihe/fhir/r4/core/src/main/java/org/openehealth/ipf/commons/ihe/fhir/support/audit/marshal/AbstractFhirAuditSerializationStrategy.java
@@ -85,8 +85,13 @@ abstract class AbstractFhirAuditSerializationStrategy implements SerializationSt
             .setRecorded(Date.from(eit.getEventDateTime()))
             .setOutcome(getAuditEventOutcome(eit.getEventOutcomeIndicator()))
             .setOutcomeDesc(eit.getEventOutcomeDescription());
-        eit.getEventTypeCode().forEach(etc ->
-            auditEvent.addSubtype(codedValueTypeToCoding(etc)));
+        eit.getEventTypeCode().forEach(etc -> {
+            if ("IHE Transactions".equals(etc.getCodeSystemName())) {
+                auditEvent.addSubtype(codedValueTypeToCoding(etc, IHE_SYSTEM_NAME));
+            } else {
+                auditEvent.addSubtype(codedValueTypeToCoding(etc));
+            }
+        });
         eit.getPurposesOfUse().forEach(pou ->
             auditEvent.addPurposeOfEvent(codedValueTypeToCodeableConcept(pou)));
 

--- a/commons/ihe/fhir/r4/core/src/test/java/org/openehealth/ipf/commons/ihe/fhir/support/audit/marshal/AbstractFhirAuditSerializationStrategyTest.java
+++ b/commons/ihe/fhir/r4/core/src/test/java/org/openehealth/ipf/commons/ihe/fhir/support/audit/marshal/AbstractFhirAuditSerializationStrategyTest.java
@@ -1,0 +1,74 @@
+package org.openehealth.ipf.commons.ihe.fhir.support.audit.marshal;
+
+import org.hl7.fhir.r4.model.AuditEvent;
+import org.hl7.fhir.r4.model.Coding;
+import org.junit.jupiter.api.Test;
+import org.openehealth.ipf.commons.audit.model.AuditMessage;
+import org.openehealth.ipf.commons.audit.unmarshal.dicom.DICOMAuditParser;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AbstractFhirAuditSerializationStrategyTest {
+
+    @Test
+    void testSerializationFromAtnaAuditMessage() throws IOException {
+        final var serializationStrategy = new BalpJsonSerializationStrategy();
+        final var auditMessage = this.readAuditMessageResource("/audit-message-iti55.xml");
+        final var auditEvent = serializationStrategy.translate(auditMessage);
+
+        assertNotNull(auditEvent);
+        assertTrue(new Coding("http://dicom.nema.org/resources/ontology/DCM", "110112", "Query")
+                       .equalsDeep(auditEvent.getType()));
+        assertEquals(1, auditEvent.getSubtype().size());
+        assertTrue(new Coding("urn:ihe:event-type-code", "ITI-55", "Cross Gateway Patient Discovery")
+                       .equalsDeep(auditEvent.getSubtype().get(0)));
+        assertEquals(AuditEvent.AuditEventAction.E, auditEvent.getAction());
+        assertEquals(Date.from(Instant.ofEpochMilli(1740503022163L)), auditEvent.getRecorded());
+        assertEquals(AuditEvent.AuditEventOutcome._0, auditEvent.getOutcome());
+
+        assertEquals(2, auditEvent.getAgent().size());
+        var agent = auditEvent.getAgent().get(0);
+        assertTrue(new Coding("http://dicom.nema.org/resources/ontology/DCM", "110153", "Source Role ID")
+                       .equalsDeep(agent.getType().getCodingFirstRep()));
+        assertEquals("2316", agent.getAltId());
+        assertTrue(agent.getRequestor());
+        assertEquals("192.168.42.20", agent.getNetwork().getAddress());
+        assertEquals(AuditEvent.AuditEventAgentNetworkType._2, agent.getNetwork().getType());
+
+        agent = auditEvent.getAgent().get(1);
+        assertTrue(new Coding("http://dicom.nema.org/resources/ontology/DCM", "110152", "Destination Role ID")
+                       .equalsDeep(agent.getType().getCodingFirstRep()));
+        assertEquals("http://localhost:62086/ipf/iti55", agent.getWho().getDisplay());
+        assertFalse(agent.getRequestor());
+        assertEquals("localhost", agent.getNetwork().getAddress());
+        assertEquals(AuditEvent.AuditEventAgentNetworkType._1, agent.getNetwork().getType());
+
+        assertEquals("1.2.3.99", auditEvent.getSource().getSite());
+        assertEquals("IheSpringBootTest", auditEvent.getSource().getObserver().getDisplay());
+
+        assertEquals(2, auditEvent.getEntity().size());
+        var entity = auditEvent.getEntity().get(0);
+        assertTrue(new Coding("http://terminology.hl7.org/CodeSystem/audit-entity-type", "2", null)
+                       .equalsDeep(entity.getType()));
+        assertTrue(new Coding("http://terminology.hl7.org/CodeSystem/object-role", "24", null)
+                       .equalsDeep(entity.getRole()));
+        assertNotNull(entity.getQuery());
+
+        entity = auditEvent.getEntity().get(1);
+        assertTrue(new Coding("http://terminology.hl7.org/CodeSystem/audit-entity-type", "4", null)
+                       .equalsDeep(entity.getType()));
+        assertTrue(new Coding("http://terminology.hl7.org/CodeSystem/object-role", "26", null)
+                       .equalsDeep(entity.getRole()));
+        assertEquals("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01", entity.getWhat().getDisplay());
+    }
+
+    private AuditMessage readAuditMessageResource(final String filename) throws IOException {
+        final var content = getClass().getResourceAsStream(filename).readAllBytes();
+        return new DICOMAuditParser().parse(new String(content, StandardCharsets.UTF_8), false);
+    }
+}

--- a/commons/ihe/fhir/r4/core/src/test/java/org/openehealth/ipf/commons/ihe/fhir/support/audit/marshal/AbstractFhirAuditSerializationStrategyTest.java
+++ b/commons/ihe/fhir/r4/core/src/test/java/org/openehealth/ipf/commons/ihe/fhir/support/audit/marshal/AbstractFhirAuditSerializationStrategyTest.java
@@ -64,7 +64,7 @@ class AbstractFhirAuditSerializationStrategyTest {
                        .equalsDeep(entity.getType()));
         assertTrue(new Coding("http://terminology.hl7.org/CodeSystem/object-role", "26", null)
                        .equalsDeep(entity.getRole()));
-        assertEquals("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01", entity.getWhat().getDisplay());
+        assertEquals("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01", entity.getWhat().getIdentifier().getValue());
     }
 
     private AuditMessage readAuditMessageResource(final String filename) throws IOException {

--- a/commons/ihe/fhir/r4/core/src/test/resources/audit-message-iti55.xml
+++ b/commons/ihe/fhir/r4/core/src/test/resources/audit-message-iti55.xml
@@ -1,0 +1,23 @@
+<AuditMessage>
+    <EventIdentification EventActionCode="E" EventDateTime="2025-02-25T17:03:42.163Z" EventOutcomeIndicator="0">
+        <EventID csd-code="110112" codeSystemName="DCM" originalText="Query" />
+        <EventTypeCode csd-code="ITI-55" codeSystemName="IHE Transactions" originalText="Cross Gateway Patient Discovery" />
+        <EventOutcomeDescription />
+    </EventIdentification>
+    <ActiveParticipant UserID="unknown" AlternativeUserID="2316" UserIsRequestor="true" NetworkAccessPointID="192.168.42.20" NetworkAccessPointTypeCode="2">
+        <RoleIDCode csd-code="110153" codeSystemName="DCM" originalText="Source Role ID" />
+    </ActiveParticipant>
+    <ActiveParticipant UserID="http://localhost:62086/ipf/iti55" UserIsRequestor="false" NetworkAccessPointID="localhost" NetworkAccessPointTypeCode="1">
+        <RoleIDCode csd-code="110152" codeSystemName="DCM" originalText="Destination Role ID" />
+    </ActiveParticipant>
+    <AuditSourceIdentification AuditEnterpriseSiteID="1.2.3.99" AuditSourceID="IheSpringBootTest">
+        <AuditSourceTypeCode csd-code="4" codeSystemName="DCM" originalText="Application Server Process or Thread" />
+    </AuditSourceIdentification>
+    <ParticipantObjectIdentification ParticipantObjectID="322934b1-49c1-45bf-a365-5a30268d266e@2.25" ParticipantObjectTypeCode="2" ParticipantObjectTypeCodeRole="24">
+        <ParticipantObjectIDTypeCode csd-code="ITI-55" codeSystemName="IHE Transactions" originalText="Cross Gateway Patient Discovery" />
+        <ParticipantObjectQuery>PHF1ZXJ5QnlQYXJhbWV0ZXI+CiAgPHF1ZXJ5SWQgLz4KICA8c3RhdHVzQ29kZSBjb2RlPSJuZXciIC8+CiAgPHJlc3BvbnNlTW9kYWxpdHlDb2RlIGNvZGU9IlIiIC8+CiAgPHJlc3BvbnNlUHJpb3JpdHlDb2RlIGNvZGU9IkkiIC8+CiAgPHBhcmFtZXRlckxpc3Q+CiAgICA8bGl2aW5nU3ViamVjdElkPgogICAgICA8dmFsdWUgZXh0ZW5zaW9uPSJQMSIgcm9vdD0iMi4xNi43NTYuNS4zMC4xLjEyNy4zLjEwLjMiIC8+CiAgICAgIDxzZW1hbnRpY3NUZXh0PkxpdmluZ1N1YmplY3QuaWQ8L3NlbWFudGljc1RleHQ+CiAgICA8L2xpdmluZ1N1YmplY3RJZD4KICA8L3BhcmFtZXRlckxpc3Q+CjwvcXVlcnlCeVBhcmFtZXRlcj4=</ParticipantObjectQuery>
+    </ParticipantObjectIdentification>
+    <ParticipantObjectIdentification ParticipantObjectID="00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01" ParticipantObjectTypeCode="4" ParticipantObjectTypeCodeRole="26">
+        <ParticipantObjectIDTypeCode csd-code="traceparent" codeSystemName="e-health-suisse" originalText="traceparent" />
+    </ParticipantObjectIdentification>
+</AuditMessage>

--- a/commons/ihe/hl7v2/src/main/java/org/openehealth/ipf/commons/ihe/hl7v2/audit/codes/MllpEventTypeCode.java
+++ b/commons/ihe/hl7v2/src/main/java/org/openehealth/ipf/commons/ihe/hl7v2/audit/codes/MllpEventTypeCode.java
@@ -41,7 +41,7 @@ public enum MllpEventTypeCode implements EventType, EnumeratedCodedValue<EventTy
     private final EventType value;
 
     MllpEventTypeCode(String code, String displayName) {
-        this.value = EventType.of(code, "IHE Transactions", displayName);
+        this.value = EventType.of(code, CODE_SYSTEM_NAME_IHE_TRANSACTIONS, displayName);
     }
 
 }

--- a/commons/ihe/hl7v2/src/main/java/org/openehealth/ipf/commons/ihe/hl7v2/audit/codes/MllpParticipantObjectIdTypeCode.java
+++ b/commons/ihe/hl7v2/src/main/java/org/openehealth/ipf/commons/ihe/hl7v2/audit/codes/MllpParticipantObjectIdTypeCode.java
@@ -43,7 +43,7 @@ public enum MllpParticipantObjectIdTypeCode implements ParticipantObjectIdType, 
     private final ParticipantObjectIdType value;
 
     MllpParticipantObjectIdTypeCode(String code, String displayName) {
-        this.value = ParticipantObjectIdType.of(code, "IHE Transactions", displayName);
+        this.value = ParticipantObjectIdType.of(code, CODE_SYSTEM_NAME_IHE_TRANSACTIONS, displayName);
     }
 
 }

--- a/commons/ihe/hl7v3/src/main/java/org/openehealth/ipf/commons/ihe/hl7v3/audit/codes/Hl7v3EventTypeCode.java
+++ b/commons/ihe/hl7v3/src/main/java/org/openehealth/ipf/commons/ihe/hl7v3/audit/codes/Hl7v3EventTypeCode.java
@@ -40,7 +40,7 @@ public enum Hl7v3EventTypeCode implements EventType, EnumeratedCodedValue<EventT
     private final EventType value;
 
     Hl7v3EventTypeCode(String code, String displayName) {
-        this.value = EventType.of(code, "IHE Transactions", displayName);
+        this.value = EventType.of(code, CODE_SYSTEM_NAME_IHE_TRANSACTIONS, displayName);
     }
 
 }

--- a/commons/ihe/hl7v3/src/main/java/org/openehealth/ipf/commons/ihe/hl7v3/audit/codes/Hl7v3ParticipantObjectIdTypeCode.java
+++ b/commons/ihe/hl7v3/src/main/java/org/openehealth/ipf/commons/ihe/hl7v3/audit/codes/Hl7v3ParticipantObjectIdTypeCode.java
@@ -40,7 +40,7 @@ public enum Hl7v3ParticipantObjectIdTypeCode implements ParticipantObjectIdType,
     private final ParticipantObjectIdType value;
 
     Hl7v3ParticipantObjectIdTypeCode(String code, String displayName) {
-        this.value = ParticipantObjectIdType.of(code, "IHE Transactions", displayName);
+        this.value = ParticipantObjectIdType.of(code, CODE_SYSTEM_NAME_IHE_TRANSACTIONS, displayName);
     }
 
 }

--- a/commons/ihe/hpd/src/main/java/org/openehealth/ipf/commons/ihe/hpd/audit/codes/HpdEventTypeCode.java
+++ b/commons/ihe/hpd/src/main/java/org/openehealth/ipf/commons/ihe/hpd/audit/codes/HpdEventTypeCode.java
@@ -32,7 +32,7 @@ public enum HpdEventTypeCode implements EventType, EnumeratedCodedValue<EventTyp
     private final EventType value;
 
     HpdEventTypeCode(String code, String displayName) {
-        this.value = EventType.of(code, "IHE Transactions", displayName);
+        this.value = EventType.of(code, CODE_SYSTEM_NAME_IHE_TRANSACTIONS, displayName);
     }
 
 }

--- a/commons/ihe/svs/src/main/java/org/openehealth/ipf/commons/ihe/svs/core/audit/SvsEventTypeCode.java
+++ b/commons/ihe/svs/src/main/java/org/openehealth/ipf/commons/ihe/svs/core/audit/SvsEventTypeCode.java
@@ -33,6 +33,6 @@ public enum SvsEventTypeCode implements EventType, EnumeratedCodedValue<EventTyp
     private final EventType value;
 
     SvsEventTypeCode(String code, String displayName) {
-        this.value = EventType.of(code, "IHE Transactions", displayName);
+        this.value = EventType.of(code, CODE_SYSTEM_NAME_IHE_TRANSACTIONS, displayName);
     }
 }

--- a/commons/ihe/xacml20/impl/src/main/java/org/openehealth/ipf/commons/ihe/xacml20/audit/codes/Xacml20EventTypeCodes.java
+++ b/commons/ihe/xacml20/impl/src/main/java/org/openehealth/ipf/commons/ihe/xacml20/audit/codes/Xacml20EventTypeCodes.java
@@ -26,10 +26,10 @@ import org.openehealth.ipf.commons.audit.types.EventType;
  * @since 3.5.1
  */
 public enum Xacml20EventTypeCodes implements EventType, EnumeratedCodedValue<EventType> {
-    PrivacyPolicyFeed             ("PPQ-1",  "e-health-suisse",  "Privacy Policy Feed"),
-    PrivacyPolicyRetrieve         ("PPQ-2",  "e-health-suisse",  "Privacy Policy Retrieve"),
-    AuthorizationDecisionsQueryIhe("ITI-79", "IHE Transactions", "Authorization Decisions Query"),
-    AuthorizationDecisionsQueryAdr("ADR",    "e-health-suisse",  "Authorization Decisions Query"),
+    PrivacyPolicyFeed             ("PPQ-1",  CODE_SYSTEM_NAME_EHS,  "Privacy Policy Feed"),
+    PrivacyPolicyRetrieve         ("PPQ-2",  CODE_SYSTEM_NAME_EHS,  "Privacy Policy Retrieve"),
+    AuthorizationDecisionsQueryIhe("ITI-79", CODE_SYSTEM_NAME_IHE_TRANSACTIONS, "Authorization Decisions Query"),
+    AuthorizationDecisionsQueryAdr("ADR",    CODE_SYSTEM_NAME_EHS,  "Authorization Decisions Query"),
     ;
 
     @Getter

--- a/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/audit/codes/XdsEventTypeCode.java
+++ b/commons/ihe/xds/src/main/java/org/openehealth/ipf/commons/ihe/xds/core/audit/codes/XdsEventTypeCode.java
@@ -52,7 +52,7 @@ public enum XdsEventTypeCode implements EventType, EnumeratedCodedValue<EventTyp
     private final EventType value;
 
     XdsEventTypeCode(String code, String displayName) {
-        this.value = EventType.of(code, "IHE Transactions", displayName);
+        this.value = EventType.of(code, CODE_SYSTEM_NAME_IHE_TRANSACTIONS, displayName);
     }
 
 }


### PR DESCRIPTION
Fixes #469 

NB1: about the mapping from _RoleIDCode_ to `agent.type`, now only the first value is mapped and subsequent ones are lost. We could map additional values to `agent.role` if necessary?

NB2: about the "_IHE Transactions_" system: with that fix, we can now generate valid BALP AuditEvents from non-FHIR transactions, but the reverse (generating a valid ATNA AuditMessage from a FHIR transaction) is not true because FHIR transactions directly set the FHIR system, not the DICOM one. I don't know if that's a real usecase.