### PR TITLE
#471: catch exception when intercepting a SOAP fault for auditing

### DIFF
--- a/commons/ihe/ws/src/main/java/org/openehealth/ipf/commons/ihe/ws/cxf/audit/AuditResponseInterceptor.java
+++ b/commons/ihe/ws/src/main/java/org/openehealth/ipf/commons/ihe/ws/cxf/audit/AuditResponseInterceptor.java
@@ -102,8 +102,15 @@ public class AuditResponseInterceptor<T extends WsAuditDataset> extends Abstract
         // check whether the response is relevant for ATNA audit finalization
         var response = extractPojo(message);
         var auditStrategy = getAuditStrategy();
-        if (! auditStrategy.isAuditableResponse(response)) {
-            return;
+        if (response != null) {
+            try {
+                if (!auditStrategy.isAuditableResponse(response)) {
+                    return;
+                }
+            } catch (final Exception e) {
+                // Ignore the XML slurping exception and set the response as unprocessable
+                response = null;
+            }
         }
 
         T auditDataset = null;


### PR DESCRIPTION
Fixes #471

That fix protects both against empty responses (like SOAP faults) and malformed responses that would otherwise throw an uncaught exception.