### PR TITLE
allow more customization of AcknowledgmentDetail via Hl7v3Exception

### DIFF
--- a/commons/ihe/hl7v3/src/main/groovy/org/openehealth/ipf/commons/ihe/hl7v3/Hl7v3Exception.groovy
+++ b/commons/ihe/hl7v3/src/main/groovy/org/openehealth/ipf/commons/ihe/hl7v3/Hl7v3Exception.groovy
@@ -63,6 +63,9 @@ class Hl7v3Exception extends RuntimeException {
 
     // value set: AcknowledgementDetailCode
     String acknowledgementDetailCode = 'INTERR'
+    String acknowledgementDetailCodeSystem = '2.16.840.1.113883.5.1100'
+
+    String acknowledgementDetailLocation
 
     // value set: QueryResponse
     String queryResponseCode = 'AE'

--- a/commons/ihe/hl7v3/src/main/groovy/org/openehealth/ipf/commons/ihe/hl7v3/Hl7v3NakFactory.groovy
+++ b/commons/ihe/hl7v3/src/main/groovy/org/openehealth/ipf/commons/ihe/hl7v3/Hl7v3NakFactory.groovy
@@ -100,6 +100,8 @@ class Hl7v3NakFactory {
         // variables below will be used only when the parameter "throwable" is not null
         String statusCode0
         String acknowledgementDetailCode0
+        String acknowledgementDetailCodeSystem0
+        String acknowledgementDetailLocation
         String detectedIssueEventCode0
         String detectedIssueEventCodeSystem0
         String detectedIssueManagementCode0
@@ -116,6 +118,8 @@ class Hl7v3NakFactory {
             Hl7v3Exception hl7v3exception = (Hl7v3Exception) throwable
             typeCode0                          = hl7v3exception.typeCode
             acknowledgementDetailCode0         = hl7v3exception.acknowledgementDetailCode
+            acknowledgementDetailCodeSystem0   = hl7v3exception.acknowledgementDetailCodeSystem
+            acknowledgementDetailLocation      = hl7v3exception.acknowledgementDetailLocation
             queryResponseCode0                 = hl7v3exception.queryResponseCode
             statusCode0                        = hl7v3exception.statusCode
             detectedIssueEventCode0            = hl7v3exception.detectedIssueEventCode
@@ -158,8 +162,11 @@ class Hl7v3NakFactory {
                 }
                 if (throwable) {
                     acknowledgementDetail(typeCode: 'E') {
-                        code(code: acknowledgementDetailCode0, codeSystem: '2.16.840.1.113883.5.1100')
+                        code(code: acknowledgementDetailCode0, codeSystem: acknowledgementDetailCodeSystem0)
                         text(throwable.getMessage())
+                        if(acknowledgementDetailLocation) {
+                            location(acknowledgementDetailLocation)
+                        }
                     }
                 }
             }

--- a/platform-camel/ihe/hl7v3/src/test/groovy/org/openehealth/ipf/platform/camel/ihe/hl7v3/iti45/Iti45TestRouteBuilder.groovy
+++ b/platform-camel/ihe/hl7v3/src/test/groovy/org/openehealth/ipf/platform/camel/ihe/hl7v3/iti45/Iti45TestRouteBuilder.groovy
@@ -16,6 +16,7 @@
 package org.openehealth.ipf.platform.camel.ihe.hl7v3.iti45
 
 import org.apache.camel.builder.RouteBuilder
+import org.openehealth.ipf.commons.ihe.hl7v3.Hl7v3Exception
 import org.openehealth.ipf.platform.camel.core.util.Exchanges
 import org.openehealth.ipf.platform.camel.ihe.hl7v3.PixPdqV3CamelValidators
 import org.openehealth.ipf.platform.camel.ihe.ws.StandardTestContainer
@@ -44,6 +45,15 @@ class Iti45TestRouteBuilder extends RouteBuilder {
                     <PRPA_IN201310UV02 xmlns="urn:hl7-org:v3" from="PIX Manager"/>
                     <!-- comment 3 -->
                 ''')
+
+        from('pixv3-iti45:pixv3-iti45-serviceNak1?audit=false')
+            .process({
+                Hl7v3Exception exception = new Hl7v3Exception("ERROR")
+                exception.acknowledgementDetailCode = '204'
+                exception.acknowledgementDetailCodeSystem = '2.16.840.1.113883.18.217'
+                exception.acknowledgementDetailLocation = '/PRPA_IN201309UV02/controlActProcess/queryByParameter/parameterList/patientIdentifier[1]'
+                throw exception
+            })
 
     }
 }


### PR DESCRIPTION
Cases 4 and 5 in the [ITI-45 spec](https://profiles.ihe.net/ITI/TF/Volume2/ITI-45.html#3.45.4.2.3) and case 3 in [ITI-47](https://profiles.ihe.net/ITI/TF/Volume2/ITI-47.html#3.47.4.2.3) require setting `code` and `location` in `AcknowledgmentDetail`.
The code `204` seems to be from the code system `2.16.840.1.113883.18.217` instead of the currently fixed `2.16.840.1.113883.5.1100`.
To not make this a breaking change, I didn't touch `Hl7v3Exception::make`, but there might be an argument to do this.