### PR TITLE
Improve support for ATNA roleIDCodes translation

### DIFF
--- a/commons/ihe/fhir/r4/audit/src/main/groovy/org/openehealth/ipf/commons/ihe/fhir/atna/translation/AuditRecordTranslator.groovy
+++ b/commons/ihe/fhir/r4/audit/src/main/groovy/org/openehealth/ipf/commons/ihe/fhir/atna/translation/AuditRecordTranslator.groovy
@@ -82,7 +82,12 @@ class AuditRecordTranslator implements ToFhirTranslator<AuditMessage> {
 
     static AuditEvent.AuditEventAgentComponent participant(ActiveParticipantType atna) {
         AuditEvent.AuditEventAgentComponent fhir = new AuditEvent.AuditEventAgentComponent(new BooleanType(atna.userIsRequestor))
-        fhir.setType(codeableConcept(atna.roleIDCodes.first()))
+        if (atna.roleIDCodes != null && !atna.roleIDCodes.isEmpty()) {
+            fhir.setType(codeableConcept(atna.roleIDCodes.first()))
+            if (atna.roleIDCodes.size() > 1) {
+                atna.roleIDCodes.tail().each { fhir.addRole(codeableConcept(it)) }
+            }
+        }
         fhir.who = new Reference(identifier: new Identifier(value: atna.userID))
         fhir.altId = atna.alternativeUserID
         fhir.name = atna.userName

--- a/commons/ihe/fhir/r4/audit/src/test/groovy/org/openehealth/ipf/commons/ihe/fhir/atna/translation/AuditRecordTranslatorTest.groovy
+++ b/commons/ihe/fhir/r4/audit/src/test/groovy/org/openehealth/ipf/commons/ihe/fhir/atna/translation/AuditRecordTranslatorTest.groovy
@@ -153,6 +153,24 @@ class AuditRecordTranslatorTest {
         log.debug('FHIR validation result:\n{}', parser.encodeResourceToString(operationOutcome))
 
         assert validationResult.successful
+
+        assert fhir.agent.size() == 4
+
+        assert fhir.agent[0].type.coding[0].code == '110153'
+        assert fhir.agent[0].who.identifier.value == 'https://community.epr.ch/Repository'
+        assert !fhir.agent[0].hasRole()
+
+        assert fhir.agent[1].type.coding[0].code == '110152'
+        assert fhir.agent[1].who.identifier.value == '1234'
+        assert !fhir.agent[1].hasRole()
+
+        assert !fhir.agent[2].hasType()
+        assert fhir.agent[2].who.identifier.value == '7601002860123'
+        assert !fhir.agent[2].hasRole()
+
+        assert fhir.agent[3].type.coding[0].code == 'HCP'
+        assert fhir.agent[3].who.identifier.value == '7601002860123'
+        assert fhir.agent[3].role[0].coding[0].code == '223366009'
     }
 
 }

--- a/commons/ihe/fhir/r4/audit/src/test/resources/atna-record-2.xml
+++ b/commons/ihe/fhir/r4/audit/src/test/resources/atna-record-2.xml
@@ -10,11 +10,12 @@
     <ActiveParticipant UserID="1234" AlternativeUserID="1234" UserIsRequestor="false" NetworkAccessPointID="10.0.1.42" NetworkAccessPointTypeCode="2">
         <RoleIDCode codeSystemName="DCM" csd-code="110152" originalText="Destination Role ID" />
     </ActiveParticipant>
-    <ActiveParticipant UserID="7601002860123" UserName="&lt;7601002860123@http://ith-icoserve.com/eHealthSolutionsSTS&gt;" UserIsRequestor="false">
-        <RoleIDCode codeSystemName="2.16.756.5.30.1.127.3.10.6" originalText="Healthcare Professional" csd-code="HCP" />
-    </ActiveParticipant>
+    <ActiveParticipant UserID="7601002860123"
+                       UserName="&lt;7601002860123@http://ith-icoserve.com/eHealthSolutionsSTS&gt;"
+                       UserIsRequestor="false" />
     <ActiveParticipant UserID="7601002860123" UserName="Quentin Ligier" UserIsRequestor="true">
         <RoleIDCode codeSystemName="2.16.756.5.30.1.127.3.10.6" originalText="Healthcare Professional" csd-code="HCP" />
+        <RoleIDCode codeSystemName="2.16.840.1.113883.6.96" originalText="Healthcare professional (occupation)" csd-code="223366009" />
     </ActiveParticipant>
     <AuditSourceIdentification AuditEnterpriseSiteID="2.16.756.1.2.3" AuditSourceID="d7251114" />
     <ParticipantObjectIdentification ParticipantObjectID="2.16.756.5.30.1.191.1.0.12.3.101^e90afe4e-49c8-4140-94b0-b74f68c3678b" ParticipantObjectTypeCode="2" ParticipantObjectTypeCodeRole="3">


### PR DESCRIPTION
The current code (`AuditRecordTranslator`) crashes if an ActiveParticipant has no `roleIDCode` (which can happen, as per the DICOM schema). It was introduced in #470. I fixed it.
I also improved the mapping by setting additional `roleIDCodes` to `AuditEvent.role`. That should not probably never happen, but it's best not to lose information here. It's coherent with the FHIR mapping (which associations `roleIDCode` to both `AuditEvent.type` and `AuditEvent.role`).

Tests were updated to cover both use cases.

```
Cannot access first() element from an empty List
java.util.NoSuchElementException: Cannot access first() element from an empty List
	at org.codehaus.groovy.runtime.DefaultGroovyMethods.first(DefaultGroovyMethods.java:10343)
	at org.codehaus.groovy.runtime.dgm$306.doMethodInvoke(Unknown Source)
	at org.codehaus.groovy.vmplugin.v8.IndyInterface.fromCache(IndyInterface.java:321)
	at org.openehealth.ipf.commons.ihe.fhir.atna.translation.AuditRecordTranslator.participant(AuditRecordTranslator.groovy:85)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:343)
	at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:328)
	at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:343)
	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1007)
	at org.codehaus.groovy.vmplugin.v8.IndyInterface.fromCache(IndyInterface.java:321)
	at org.openehealth.ipf.commons.ihe.fhir.atna.translation.AuditRecordTranslator$_translateToFhir_closure5.doCall(AuditRecordTranslator.groovy:120)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:343)
	at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:328)
	at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:280)
	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1007)
	at groovy.lang.Closure.call(Closure.java:433)
	at groovy.lang.Closure.call(Closure.java:422)
	at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:2394)
	at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:2379)
	at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:2420)
	at org.codehaus.groovy.runtime.dgm$207.doMethodInvoke(Unknown Source)
	at org.codehaus.groovy.vmplugin.v8.IndyInterface.fromCache(IndyInterface.java:321)
	at org.openehealth.ipf.commons.ihe.fhir.atna.translation.AuditRecordTranslator.translateToFhir(AuditRecordTranslator.groovy:120)
	at org.codehaus.groovy.vmplugin.v8.IndyInterface.fromCache(IndyInterface.java:321)
	at org.openehealth.ipf.commons.ihe.fhir.atna.translation.AuditRecordTranslator.translate(AuditRecordTranslator.groovy:112)
```