### PR TITLE
fix potential NullPointerException  in ApacheHttpRequest5.getRequestB…

### DIFF
--- a/commons/ihe/fhir/core/src/main/java/org/openehealth/ipf/commons/ihe/fhir/ApacheHttpRequest5.java
+++ b/commons/ihe/fhir/core/src/main/java/org/openehealth/ipf/commons/ihe/fhir/ApacheHttpRequest5.java
@@ -73,7 +73,7 @@ public class ApacheHttpRequest5 extends BaseHttpRequest implements IHttpRequest 
     @Override
     public String getRequestBodyFromStream() throws IOException {
         var entity = request.getEntity();
-        if (entity.isRepeatable()) {
+        if (entity != null && entity.isRepeatable()) {
             final var contentTypeHeader = request.getFirstHeader("Content-Type");
             var charset = contentTypeHeader == null
                 ? null


### PR DESCRIPTION
Adding a LoggingInterceptor can lead to a NullPointerException for GET and Search Requests.

`client.registerInterceptor(new LoggingInterceptor(true));`

Exception:
```
java.lang.NullPointerException: Cannot invoke "org.apache.hc.core5.http.HttpEntity.isRepeatable()" because "entity" is null
at org.openehealth.ipf.commons.ihe.fhir.ApacheHttpRequest5.getRequestBodyFromStream(ApacheHttpRequest5.java:76)
    at ca.uhn.fhir.rest.client.interceptor.LoggingInterceptor.interceptRequest(LoggingInterceptor.java:92)
    at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(Unknown Source)
    at java.base/java.lang.reflect.Method.invoke(Unknown Source)
    at ca.uhn.fhir.interceptor.executor.BaseInterceptorService$HookInvoker.invokeMethod(BaseInterceptorService.java:630)
```