### PR TITLE
mssing toString override in ApacheHttpRequest5.java

### DIFF
--- a/commons/ihe/fhir/core/src/main/java/org/openehealth/ipf/commons/ihe/fhir/ApacheHttpRequest5.java
+++ b/commons/ihe/fhir/core/src/main/java/org/openehealth/ipf/commons/ihe/fhir/ApacheHttpRequest5.java
@@ -102,4 +102,9 @@ public class ApacheHttpRequest5 extends BaseHttpRequest implements IHttpRequest 
     public void removeHeaders(String name) {
         request.removeHeaders(name);
     }
+
+    @Override
+    public String toString() {
+        return request.toString();
+    }
 }


### PR DESCRIPTION
https://github.com/hapifhir/hapi-fhir/blob/93cb7160a54d374f9baa4341fca13138f6043cec/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/interceptor/LoggingInterceptor.java#L82
```
		if (myLogRequestSummary) {
			myLog.info("Client request: {}", theRequest);
		}
```

Without a toString() override on the request object, the log output looks like this:

```
Client request: org.openehealth.ipf.commons.ihe.fhir.ApacheHttpRequest5@4710943d Caller+0	 at ca.uhn.fhir.rest.client.interceptor.LoggingInterceptor.interceptRequest(LoggingInterceptor.java:82)
```