### PR TITLE
Improve SyslogParser conformance to RFC5424

### DIFF
--- a/commons/audit/src/main/java/org/openehealth/ipf/commons/audit/server/support/SyslogDetailsBuilder.java
+++ b/commons/audit/src/main/java/org/openehealth/ipf/commons/audit/server/support/SyslogDetailsBuilder.java
@@ -104,7 +104,7 @@ class SyslogDetailsBuilder {
     }
 
     public SyslogDetailsBuilder addMessage(String message) {
-        result.put(MESSAGE, message != null ? message.trim() : "");
+        result.put(MESSAGE, message != null ? message : "");
         return this;
     }
 

--- a/commons/audit/src/main/java/org/openehealth/ipf/commons/audit/server/support/SyslogParser.java
+++ b/commons/audit/src/main/java/org/openehealth/ipf/commons/audit/server/support/SyslogParser.java
@@ -25,13 +25,13 @@ public class SyslogParser {
 
     private static final Logger log = LoggerFactory.getLogger(SyslogParser.class);
     private static final Pattern syslogPattern = Pattern.compile(
-            "^<(\\d{1,3})>(\\d)\\s" +    // PRI and VERSION
-            "(\\S+)\\s" +                // TIMESTAMP
-            "(\\S+)\\s" +                // HOSTNAME
-            "(\\S+)\\s" +                // APP-NAME
-            "(\\S+)\\s" +                // PROCID
-            "(\\S+)\\s" +                // MSGID
-            "(\\[.*?]|-)\\s*" +          // STRUCTURED-DATA
+            "^<(\\d{1,3})>(\\d{1,3}) " + // PRI and VERSION
+            "(\\S+) " +                  // TIMESTAMP
+            "(\\S{1,255}) " +            // HOSTNAME
+            "(\\S{1,48}) " +             // APP-NAME
+            "(\\S{1,128}) " +            // PROCID
+            "(\\S{1,32}) " +             // MSGID
+            "(\\[.*?]|-) " +             // STRUCTURED-DATA
             "(.*)$"                      // MESSAGE
     );
 

--- a/commons/audit/src/test/java/org/openehealth/ipf/commons/audit/server/support/SyslogParserTest.java
+++ b/commons/audit/src/test/java/org/openehealth/ipf/commons/audit/server/support/SyslogParserTest.java
@@ -71,6 +71,14 @@ class SyslogParserTest {
         assertThat(result, hasTimestamp(Instant.parse("2023-04-18T14:32:52Z")));
     }
 
+    @Test
+    void shouldParseMessageWithBom() {
+        var msg = "<13>1 2023-04-18T14:32:52Z localhost logger 321 ID10 - \uFEFFA UTF-8 message with BOM\uD83D\uDC27";
+        var result = SyslogParser.parse(msg);
+
+        assertThat(result, hasMessage("\uFEFFA UTF-8 message with BOM\uD83D\uDC27"));
+    }
+
     // --- Invalid cases using helper ---
 
     @Test


### PR DESCRIPTION
Make SyslogParser more conformant to [RFC 5424](https://datatracker.ietf.org/doc/html/rfc5424) in two ways:
- Fix the expected length of some header parts;
- Don't remove whitespaces at the beginning and end of the message. More specifically, keep the optional BOM to let the caller know about the UTF-8 encoding.

@ohr: is it OK for you?