### PR TITLE
Support multiline messages in SyslogParser

### DIFF
--- a/commons/audit/src/main/java/org/openehealth/ipf/commons/audit/server/support/SyslogParser.java
+++ b/commons/audit/src/main/java/org/openehealth/ipf/commons/audit/server/support/SyslogParser.java
@@ -33,7 +33,7 @@ public class SyslogParser {
             "(\\S{1,32}) " +             // MSGID
             "(\\[.*?]|-) " +             // STRUCTURED-DATA
             "(.*)$"                      // MESSAGE
-    );
+    , Pattern.DOTALL);
 
     public static Map<String, Object> parse(String syslogMessage) {
         if (syslogMessage == null || syslogMessage.trim().isEmpty()) {

--- a/commons/audit/src/test/java/org/openehealth/ipf/commons/audit/server/support/SyslogParserTest.java
+++ b/commons/audit/src/test/java/org/openehealth/ipf/commons/audit/server/support/SyslogParserTest.java
@@ -79,6 +79,14 @@ class SyslogParserTest {
         assertThat(result, hasMessage("\uFEFFA UTF-8 message with BOM\uD83D\uDC27"));
     }
 
+    @Test
+    void shouldParseMultilineMessage() {
+        var msg = "<13>1 2023-04-18T14:32:52Z localhost logger 321 ID10 - First line\nSecond line\r\nThird line";
+        var result = SyslogParser.parse(msg);
+
+        assertThat(result, hasMessage("First line\nSecond line\r\nThird line"));
+    }
+
     // --- Invalid cases using helper ---
 
     @Test


### PR DESCRIPTION
The SyslogParser should support multiline messages, because the [specification](https://datatracker.ietf.org/doc/html/rfc5424#page-8) allows them (`MSG` is any `OCTET`). Not supporting it will cause an issue to users that send beautified AuditMessages, or manually crafted ones.