### PR TITLE
Added status code 'aborted' for Hl7v3NakFactory

### DIFF
--- a/commons/ihe/hl7v3/src/main/groovy/org/openehealth/ipf/commons/ihe/hl7v3/Hl7v3NakFactory.groovy
+++ b/commons/ihe/hl7v3/src/main/groovy/org/openehealth/ipf/commons/ihe/hl7v3/Hl7v3NakFactory.groovy
@@ -111,6 +111,7 @@ class Hl7v3NakFactory {
         if (throwable) {
             acknowledgementDetailCode0         = 'INTERR'
             queryResponseCode0                 = 'AE'
+            statusCode0                        = 'aborted'
             detectedIssueEventCodeSystem0      = '2.16.840.1.113883.5.4'
             detectedIssueManagementCodeSystem0 = '2.16.840.1.113883.5.4'
         }


### PR DESCRIPTION
Fix missing statusCode in queryAck for ITI-47 error responses
Gazelle validation fails for some ITI-47 (PDQv3) error responses because the queryAck element is missing the required statusCode. 

Test                               constraint_mfmimt700711UV01_queryAckStatusCode
Location                       /PRPAIN201306UV02Type/controlActProcess/queryAck
Description                  QueryAck SHALL have a statusCode element (Table O.2.2-2)