### PR TITLE
Changed detectedIssueEventCode value to _ActAdministrativeDetectedIssueManagementCode

### DIFF
--- a/commons/ihe/hl7v3/src/main/groovy/org/openehealth/ipf/commons/ihe/hl7v3/Hl7v3Exception.groovy
+++ b/commons/ihe/hl7v3/src/main/groovy/org/openehealth/ipf/commons/ihe/hl7v3/Hl7v3Exception.groovy
@@ -39,7 +39,7 @@ class Hl7v3Exception extends RuntimeException {
                                String statusCode = 'aborted',
                                String acknowledgementDetailCode = 'INTERR',
                                String queryResponseCode = 'AE',
-                               String detectedIssueEventCode = 'ActAdministrativeDetectedIssueCode',
+                               String detectedIssueEventCode = '_ActAdministrativeDetectedIssueManagementCode',
                                String detectedIssueManagementCode = null) {
         Hl7v3Exception e = new Hl7v3Exception(message, cause)
         e.typeCode = typeCode
@@ -79,7 +79,7 @@ class Hl7v3Exception extends RuntimeException {
     // value set: QueryStatusCode
     String statusCode = 'aborted'
 
-    String detectedIssueEventCode = 'ActAdministrativeDetectedIssueCode'
+    String detectedIssueEventCode = '_ActAdministrativeDetectedIssueManagementCode'
     String detectedIssueEventCodeSystem = '2.16.840.1.113883.5.4'
     String detectedIssueManagementCode
     String detectedIssueManagementCodeSystem = '2.16.840.1.113883.5.4'

--- a/commons/ihe/hl7v3/src/main/groovy/org/openehealth/ipf/commons/ihe/hl7v3/Hl7v3NakFactory.groovy
+++ b/commons/ihe/hl7v3/src/main/groovy/org/openehealth/ipf/commons/ihe/hl7v3/Hl7v3NakFactory.groovy
@@ -132,7 +132,7 @@ class Hl7v3NakFactory {
             typeCode0                    = 'AE'
             acknowledgementDetailCode0   = 'SYN113'
             queryResponseCode0           = 'QE'
-            detectedIssueEventCode0      = 'ActAdministrativeDetectedIssueCode'
+            detectedIssueEventCode0      = '_ActAdministrativeDetectedIssueManagementCode'
             detectedIssueManagementCode0 = 'VALIDAT'
         }
 

--- a/platform-camel/ihe/hl7v3/src/test/groovy/org/openehealth/ipf/platform/camel/ihe/hl7v3/iti47/TestIti47.groovy
+++ b/platform-camel/ihe/hl7v3/src/test/groovy/org/openehealth/ipf/platform/camel/ihe/hl7v3/iti47/TestIti47.groovy
@@ -198,7 +198,7 @@ class TestIti47 extends HL7v3StandardTestContainer {
         def response = Hl7v3Utils.slurp(responseString)
         assert response.acknowledgement.typeCode.@code == 'AE'
         assert response.acknowledgement.acknowledgementDetail.code.@code == 'SYN113'
-        assert response.controlActProcess.reasonOf.detectedIssueEvent.code.@code == 'ActAdministrativeDetectedIssueCode'
+        assert response.controlActProcess.reasonOf.detectedIssueEvent.code.@code == '_ActAdministrativeDetectedIssueManagementCode'
         assert response.controlActProcess.reasonOf.detectedIssueEvent.mitigatedBy.detectedIssueManagement.code.@code == 'VALIDAT'
         assert response.controlActProcess.queryAck.statusCode.@code == 'aborted'
         assert response.controlActProcess.queryAck.queryResponseCode.@code == 'QE'

--- a/platform-camel/ihe/hl7v3/src/test/groovy/org/openehealth/ipf/platform/camel/ihe/hl7v3/iti55/TestIti55.groovy
+++ b/platform-camel/ihe/hl7v3/src/test/groovy/org/openehealth/ipf/platform/camel/ihe/hl7v3/iti55/TestIti55.groovy
@@ -200,7 +200,7 @@ class TestIti55 extends HL7v3StandardTestContainer {
 
         assert response.acknowledgement.typeCode.@code == 'AE'
         assert response.acknowledgement.acknowledgementDetail.code.@code == 'INTERR'
-        assert response.controlActProcess.reasonOf.detectedIssueEvent.code.@code == 'ActAdministrativeDetectedIssueCode'
+        assert response.controlActProcess.reasonOf.detectedIssueEvent.code.@code == '_ActAdministrativeDetectedIssueManagementCode'
         assert response.controlActProcess.reasonOf.detectedIssueEvent.mitigatedBy.detectedIssueManagement.code.@code == 'InternalError'
         assert response.controlActProcess.reasonOf.detectedIssueEvent.mitigatedBy.detectedIssueManagement.code.@codeSystem == '1.3.6.1.4.1.19376.1.2.27.3'
         assert response.controlActProcess.queryAck.statusCode.@code == 'aborted'


### PR DESCRIPTION
Fix wrong detectedIssueEventCode for ITI-47 and ITI-55 error responses.
Gazelle validation fails for some ITI-55 error responses because the detectedIssueEventCode has value _ActAdministrativeDetectedIssueCode_ instead of __ActAdministrativeDetectedIssueManagementCode_.

Test                constraint_iti55val069
Location        /PRPAIN201306UV02Type/controlActProcess/reasonOf[0]/detectedIssueEvent
Description:  detectedIssueEvent.code` code shall be set to `_ActAdministrativeDetectedIssueManagementCode