### PR TITLE
Fix case of HL7v3 statusCodes in transformers

### DIFF
--- a/commons/ihe/hl7v3model/src/main/java/org/openehealth/ipf/commons/ihe/hl7v3/core/transform/responses/PixV3QueryResponseTransformer.java
+++ b/commons/ihe/hl7v3model/src/main/java/org/openehealth/ipf/commons/ihe/hl7v3/core/transform/responses/PixV3QueryResponseTransformer.java
@@ -120,7 +120,7 @@ public class PixV3QueryResponseTransformer {
 
         final var registrationEvent =
                 new PRPAIN201310UV02MFMIMT700711UV01RegistrationEvent();
-        registrationEvent.setStatusCode(new CS("ACTIVE", null, null));
+        registrationEvent.setStatusCode(new CS("active", null, null));
         registrationEvent.setClassCode(ActClass.REG);
         registrationEvent.setMoodCode(ActMood.EVN);
         subject.setRegistrationEvent(registrationEvent);
@@ -131,7 +131,7 @@ public class PixV3QueryResponseTransformer {
 
         final var patient = new PRPAMT201304UV02Patient();
         patient.setClassCode("PAT");
-        patient.setStatusCode(new CS("ACTIVE", null, null));
+        patient.setStatusCode(new CS("active", null, null));
         patient.setId(simpleResponse.getPatientIds());
         patient.setProviderOrganization(simpleResponse.getProviderOrganization());
         subject1.setPatient(patient);

--- a/src/site/changes.xml
+++ b/src/site/changes.xml
@@ -24,6 +24,9 @@
     </properties>
     <body>
         <release version="5.2.0" description="IPF 5.2.0" date="">
+            <action issue="511" dev="qligier" type="fix">
+                Fix case of HL7v3 statusCodes in transformers
+            </action>
             <action issue="510" dev="razvanTri" type="fix">
                 Fix detected issue event code in automatically generated HL7v3 NAKs
             </action>


### PR DESCRIPTION
Two statusCodes in `PixV3QueryResponseTransformer` should be lowercased.

https://profiles.ihe.net/ITI/TF/Volume2/ITI-45.html#:~:text=Patient%20(CS)%20%7BCNE%3Aactive%2C%20fixed%20value%3D%20%22active%22%7D

https://profiles.ihe.net/ITI/TF/Volume2/ch-O.html#:~:text=Act%20%20(%20CS%20)%20%7BCNE%3A%20ActStatus%20%2C%20default%3D%20%22active%22%7D